### PR TITLE
#52 fix deprecation warnings for private repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Default: `false`
 #### pypiRepoId ####
 
 Specifies the `<id>` of the `<server>` element declared within the utilized Maven `settings.xml` configuration that represents the PyPI repository
-to which this project's archives will be published and/or used as a secondary repository from which dependencies may be installed. This property is **REQUIRED** if publishing to or consuming dependencies from a private PyPI repository that requires authentication - it is expected that the relevant `<server>` element provides the needed authentication details.
+to which this project's archives will be published and/or used as a supplemental repository from which dependencies may be installed. This property is **REQUIRED** if publishing to or consuming dependencies from a private PyPI repository that requires authentication - it is expected that the relevant `<server>` element provides the needed authentication details.
 
 If this property is **not** specified, this property will default to `pypi` and the execution of the `deploy` lifecycle phase will publish this package to the official public PyPI repository.  Downstream package publishing functionality will use the relevant `settings.xml` `<server>` declaration with `<id>pypi</id>` as credentials for publishing the package to PyPI. If developers want to use PyPI's [API tokens](https://pypi.org/help/#apitoken) instead of username/password credentials, they may do so by manually executing the appropriate Poetry command (`poetry config pypi-token.pypi my-token`) in an ad-hoc fashion prior to running `deploy`.
 
@@ -331,7 +331,7 @@ Default: `pypi`
 
 #### pypiRepoUrl ####
 
-Specifies the URL of the private PyPI repository to which this project's archives will be published and/or used as a secondary repository from which dependencies may be installed. This property is **REQUIRED** if publishing to or consuming dependencies from a private PyPI repository.  
+Specifies the URL of the private PyPI repository to which this project's archives will be published and/or used as a supplemental repository from which dependencies may be installed. This property is **REQUIRED** if publishing to or consuming dependencies from a private PyPI repository.  
 
 If the Habushu project depends on internal packages that may only be found on a private PyPI repository, developers should specify this property through the plugin's `<configuration>` definition:
 
@@ -626,7 +626,7 @@ Configures the build state needed by Habushu, ensures that the current project i
 
 ##### compile #####
 
-Installs dependencies defined in the project's `pyproject.toml` configuration, specifically by running `poetry lock` followed by `poetry install`. If a private PyPi repository is defined via **pypiRepoUrl**, it will be automatically added to the module's `pyproject.toml` configuration as a secondary source of dependencies, if it is not already configured in the `pyproject.toml`
+Installs dependencies defined in the project's `pyproject.toml` configuration, specifically by running `poetry lock` followed by `poetry install`. If a private PyPi repository is defined via **pypiRepoUrl**, it will be automatically added to the module's `pyproject.toml` configuration as a supplemental source of dependencies, if it is not already configured in the `pyproject.toml`
 
 ##### process-classes #####
 

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/AbstractHabushuMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/AbstractHabushuMojo.java
@@ -53,7 +53,7 @@ public abstract class AbstractHabushuMojo extends AbstractMojo {
     /**
      * Specifies the {@code <id>} of the {@code <server>} element declared within
      * the utilized settings.xml configuration that represents the PyPI repository
-     * to which this project's archives will be published and/or used as a secondary
+     * to which this project's archives will be published and/or used as a supplemental
      * repository from which dependencies may be installed. This property is
      * <b>REQUIRED</b> if publishing to or consuming dependencies from a private
      * PyPI repository that requires authentication - it is expected that the
@@ -71,7 +71,7 @@ public abstract class AbstractHabushuMojo extends AbstractMojo {
 
     /**
      * Specifies the URL of the private PyPI repository to which this project's
-     * archives will be published and/or used as a secondary repository from which
+     * archives will be published and/or used as a supplemental repository from which
      * dependencies may be installed. This property is <b>REQUIRED</b> if publishing
      * to or consuming dependencies from a private PyPI repository.
      */

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/InstallDependenciesMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/InstallDependenciesMojo.java
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit;
  * private PyPi repository is defined via
  * {@link AbstractHabushuMojo#pypiRepoUrl} (and
  * {@link AbstractHabushuMojo#pypiRepoId}), it will be automatically added to
- * the module's pyproject.toml configuration as a secondary source of
+ * the module's pyproject.toml configuration as a supplemental source of
  * dependencies, if it is not already configured in the pyproject.toml
  */
 @Mojo(name = "install-dependencies", defaultPhase = LifecyclePhase.COMPILE)
@@ -168,11 +168,11 @@ public class InstallDependenciesMojo extends AbstractHabushuMojo {
                                 StringUtils.isNotEmpty(this.pypiRepoId) && !PUBLIC_PYPI_REPO_ID.equals(this.pypiRepoId)
                                         ? this.pypiRepoId
                                         : "private-pypi-repo"),
-                        String.format("url = \"%s\"", pypiRepoSimpleIndexUrl), "secondary = true");
+                        String.format("url = \"%s\"", pypiRepoSimpleIndexUrl), "priority = \"supplemental\"");
                 getLog().info(String.format("Private PyPi repository entry for %s not found in pyproject.toml",
                         this.pypiRepoUrl));
                 getLog().info(String.format(
-                        "Adding %s to pyproject.toml as secondary repository from which dependencies may be installed",
+                        "Adding %s to pyproject.toml as supplemental repository from which dependencies may be installed",
                         pypiRepoSimpleIndexUrl));
                 try {
                     Files.write(getPoetryPyProjectTomlFile().toPath(), newPypiRepoSourceConfig,


### PR DESCRIPTION
Previously we were injecting the PyPi repository configured with the `pypiRepoId` setting with the following property:
`secondary = true`

However in Poetry 1.5+ the correct syntax is:
`priority = "supplemental"`

After the changes in this PR, this is what the injected repo looks like in pyproject.toml
```
# Added by habushu-maven-plugin at 2023-09-22T09:54:04.640660 to use https://nexus.test.com/repository/pypi-internal/simple/ as source PyPi repository for installing dependencies
[[tool.poetry.source]]
name = "private-pypi-repo"
url = "https://nexus.test.com/repository/pypi-internal/simple/"
priority = "supplemental"
```

And `poetry lock` no longer outputs deprecation warnings
```
$ poetry lock
Updating dependencies
Resolving dependencies... (7.0s)
```