### PR TITLE
#54 skip mojo execution if project packaging is not habushu

### DIFF
--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/AbstractHabushuMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/AbstractHabushuMojo.java
@@ -8,6 +8,8 @@ import java.time.format.DateTimeFormatter;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.settings.Settings;
@@ -27,6 +29,13 @@ public abstract class AbstractHabushuMojo extends AbstractMojo {
      */
     @Parameter(defaultValue = "${settings}", readonly = true, required = true)
     protected Settings settings;
+
+    /**
+     * The packaging type of the current Maven project. If it is not "habushu", then habushu packaging-related mojos
+     * will skip execution.
+     */
+    @Parameter(defaultValue = "${project.packaging}", readonly = true, required = true)
+    protected String packaging;
 
     /**
      * Folder in which Python source files are located - should align with Poetry's
@@ -129,6 +138,17 @@ public abstract class AbstractHabushuMojo extends AbstractMojo {
      */
     @Parameter(defaultValue = "false", property = "habushu.rewriteLocalPathDepsInArchives")
     protected boolean rewriteLocalPathDepsInArchives;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        if ("habushu".equals(packaging)) {
+            doExecute();
+        } else {
+            getLog().info("Skipping execution - packaging type is not 'habushu'");
+        }
+    }
+
+    protected abstract void doExecute() throws MojoExecutionException, MojoFailureException;
 
     /**
      * Gets the canonical path for a file without having to deal w/ checked

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/BehaveBddTestMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/BehaveBddTestMojo.java
@@ -57,7 +57,7 @@ public class BehaveBddTestMojo extends AbstractHabushuMojo {
     protected boolean skipTests;
 
     @Override
-    public void execute() throws MojoExecutionException, MojoFailureException {
+    public void doExecute() throws MojoExecutionException, MojoFailureException {
 
 	if (skipTests) {
 	    getLog().warn("Tests are skipped (-DskipTests=true)");

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/BuildDeploymentArtifactsMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/BuildDeploymentArtifactsMojo.java
@@ -58,7 +58,7 @@ public class BuildDeploymentArtifactsMojo extends AbstractHabushuMojo {
     protected File mavenArtifactFile;
 
     @Override
-    public void execute() throws MojoExecutionException, MojoFailureException {
+    public void doExecute() throws MojoExecutionException, MojoFailureException {
         PoetryCommandHelper poetryHelper = createPoetryCommandHelper();
 
         String buildCommand, buildLogMessage;

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/CleanHabushuMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/CleanHabushuMojo.java
@@ -46,6 +46,12 @@ public class CleanHabushuMojo extends CleanMojo {
     protected File targetDirectory;
 
     /**
+     * The packaging type of the current Maven project. If it is not "habushu", then this mojo will be skipped.
+     */
+    @Parameter(defaultValue = "${project.packaging}", readonly = true, required = true)
+    protected String packaging;
+
+    /**
      * Enables the explicit deletion of the virtual environment that is
      * created/managed by Poetry.
      */
@@ -93,7 +99,14 @@ public class CleanHabushuMojo extends CleanMojo {
 
     @Override
     public void execute() throws MojoExecutionException {
+        if ("habushu".equals(packaging)) {
+            clean();
+        } else {
+            getLog().info("Skipping execution - packaging type is not 'habushu'");
+        }
+    }
 
+    private void clean() throws MojoExecutionException {
         if (deleteVirtualEnv) {
             try {
                 PyenvAndPoetrySetup configureTools = new PyenvAndPoetrySetup(pythonVersion, usePyenv,

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/FormatPythonMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/FormatPythonMojo.java
@@ -20,7 +20,7 @@ public class FormatPythonMojo extends AbstractHabushuMojo {
     protected static final String BLACK_PACKAGE = "black";
 
     @Override
-    public void execute() throws MojoExecutionException {
+    public void doExecute() throws MojoExecutionException {
 
 	List<String> directoriesToFormat = new ArrayList<>();
 	if (this.sourceDirectory.exists()) {

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/InitializeHabushuMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/InitializeHabushuMojo.java
@@ -19,7 +19,7 @@ import org.technologybrewery.habushu.exec.PoetryCommandHelper;
 public class InitializeHabushuMojo extends AbstractHabushuMojo {
 
     @Override
-    public void execute() throws MojoExecutionException, MojoFailureException {
+    public void doExecute() throws MojoExecutionException, MojoFailureException {
 
         getLog().info("Validating Poetry-based project structure...");
         PoetryCommandHelper poetryHelper = createPoetryCommandHelper();

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/InstallDependenciesMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/InstallDependenciesMojo.java
@@ -122,7 +122,7 @@ public class InstallDependenciesMojo extends AbstractHabushuMojo {
     protected boolean failOnManagedDependenciesMismatches;
 
     @Override
-    public void execute() throws MojoExecutionException, MojoFailureException {
+    public void doExecute() throws MojoExecutionException, MojoFailureException {
         PoetryCommandHelper poetryHelper = createPoetryCommandHelper();
 
         processManagedDependencyMismatches();

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/PublishToPyPiRepoMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/PublishToPyPiRepoMojo.java
@@ -83,7 +83,7 @@ public class PublishToPyPiRepoMojo extends AbstractHabushuMojo {
     protected boolean skipDeploy;
 
     @Override
-    public void execute() throws MojoExecutionException, MojoFailureException {
+    public void doExecute() throws MojoExecutionException, MojoFailureException {
 	if (this.skipDeploy) {
 	    getLog().info(String.format(
 		    "Skipping deploy phase - package for %s will not be published to the configured PyPI repository",

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/RunCommandInVirtualEnvMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/RunCommandInVirtualEnvMojo.java
@@ -31,7 +31,7 @@ public class RunCommandInVirtualEnvMojo extends AbstractHabushuMojo {
     protected String runCommandArgs;
 
     @Override
-    public void execute() throws MojoExecutionException, MojoFailureException {
+    public void doExecute() throws MojoExecutionException, MojoFailureException {
 	PoetryCommandHelper poetryHelper = createPoetryCommandHelper();
 	List<String> poetryRunCommandArgs = new ArrayList<>(Arrays.asList(StringUtils.split(runCommandArgs)));
 	poetryRunCommandArgs.add(0, "run");

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/ValidatePyenvAndPoetryMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/ValidatePyenvAndPoetryMojo.java
@@ -44,7 +44,7 @@ public class ValidatePyenvAndPoetryMojo extends AbstractHabushuMojo {
     private File patchInstallScript;
 
     @Override
-    public void execute() throws MojoExecutionException, MojoFailureException {
+    public void doExecute() throws MojoExecutionException, MojoFailureException {
         PyenvAndPoetrySetup configureTools = new PyenvAndPoetrySetup(pythonVersion, usePyenv,
                 patchInstallScript, getPoetryProjectBaseDir(), rewriteLocalPathDepsInArchives, getLog());
         configureTools.execute();

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/exec/ProcessExecutor.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/exec/ProcessExecutor.java
@@ -37,171 +37,172 @@ public class ProcessExecutor {
     private Executor executor;
 
     public ProcessExecutor(File workingDirectory, List<String> command, Platform platform,
-	    Map<String, String> additionalEnvironment) {
-	this(workingDirectory, new ArrayList<>(), command, platform, additionalEnvironment, 0);
+                           Map<String, String> additionalEnvironment) {
+        this(workingDirectory, new ArrayList<>(), command, platform, additionalEnvironment, 0);
     }
 
     public ProcessExecutor(File workingDirectory, List<String> paths, List<String> command, Platform platform,
-	    Map<String, String> additionalEnvironment) {
-	this(workingDirectory, paths, command, platform, additionalEnvironment, 0);
+                           Map<String, String> additionalEnvironment) {
+        this(workingDirectory, paths, command, platform, additionalEnvironment, 0);
     }
 
     public ProcessExecutor(File workingDirectory, List<String> paths, List<String> command, Platform platform,
-	    Map<String, String> additionalEnvironment, long timeoutInSeconds) {
-	this.environment = createEnvironment(paths, platform, additionalEnvironment);
-	this.commandLine = createCommandLine(command);
-	this.executor = createExecutor(workingDirectory, timeoutInSeconds);
+                           Map<String, String> additionalEnvironment, long timeoutInSeconds) {
+        this.environment = createEnvironment(paths, platform, additionalEnvironment);
+        this.commandLine = createCommandLine(command);
+        this.executor = createExecutor(workingDirectory, timeoutInSeconds);
     }
 
     public String executeAndGetResult(final Logger logger) {
-	ByteArrayOutputStream stdout = new ByteArrayOutputStream();
-	ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+        ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+        ByteArrayOutputStream stderr = new ByteArrayOutputStream();
 
-	int exitValue = -1;
-	try {
-	    exitValue = execute(logger, stdout, stderr);
-	} catch (Throwable e) {
-	    displayProcessOutputForException(stdout, logger);
-	    displayProcessOutputForException(stderr, logger);
-	    throw new HabushuException("Could not invoke command! See output above.", e);
-	}
-	if (exitValue == 0) {
-	    String result = stdout.toString().trim();
-	    if (StringUtils.isBlank(result)) {
-		result = stderr.toString().trim();
-	    }
-	    return result;
-	} else {
-	    throw new HabushuException(stdout + " " + stderr);
-	}
+        int exitValue = -1;
+        try {
+            exitValue = execute(logger, stdout, stderr);
+        } catch (Throwable e) {
+            displayProcessOutputForException(stdout, logger);
+            displayProcessOutputForException(stderr, logger);
+            throw new HabushuException("Could not invoke command! See output above.", e);
+        }
+        if (exitValue == 0) {
+            String result = stdout.toString().trim();
+            if (StringUtils.isBlank(result)) {
+                result = stderr.toString().trim();
+            }
+            return result;
+        } else {
+            throw new HabushuException(stdout + " " + stderr);
+        }
     }
 
     @SuppressWarnings("deprecation")
     public int executeAndRedirectOutput(final Logger logger) {
-	OutputStream stdout = new LoggerOutputStream(logger, 0);
-	ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+        OutputStream stdout = new LoggerOutputStream(logger, 0);
+        ByteArrayOutputStream stderr = new ByteArrayOutputStream();
 
-	try {
-	    return execute(logger, stdout, stderr);
+        try {
+            return execute(logger, stdout, stderr);
 
-	} catch (Throwable e) {
-	    displayProcessOutputForException(stderr, logger);
-	    throw new HabushuException("Could not invoke command! See output above.", e);
+        } catch (Throwable e) {
+            displayProcessOutputForException(stderr, logger);
+            throw new HabushuException("Could not invoke command! See output above.", e);
 
-	} finally {
-	    IOUtils.closeQuietly(stdout);
-	    IOUtils.closeQuietly(stderr);
-	}
+        } finally {
+            IOUtils.closeQuietly(stdout);
+            IOUtils.closeQuietly(stderr);
+        }
     }
 
     private int execute(final Logger logger, final OutputStream stdout, final OutputStream stderr) {
-	logger.debug("Executing command line {}", commandLine);
-	try {
-	    ExecuteStreamHandler streamHandler = new PumpStreamHandler(stdout, stderr);
-	    executor.setStreamHandler(streamHandler);
+        logger.debug("Executing command line {}", commandLine);
+        logger.debug("Active PATH: {}", environment.get(PATH_ENV_VAR));
+        try {
+            ExecuteStreamHandler streamHandler = new PumpStreamHandler(stdout, stderr);
+            executor.setStreamHandler(streamHandler);
 
-	    int exitValue = executor.execute(commandLine, environment);
-	    logger.debug("Exit value {}", exitValue);
+            int exitValue = executor.execute(commandLine, environment);
+            logger.debug("Exit value {}", exitValue);
 
-	    return exitValue;
-	} catch (ExecuteException e) {
-	    if (executor.getWatchdog() != null && executor.getWatchdog().killedProcess()) {
-		throw new HabushuException("Process killed after timeout");
-	    }
-	    throw new HabushuException(e);
-	} catch (IOException e) {
-	    throw new HabushuException(e);
-	}
+            return exitValue;
+        } catch (ExecuteException e) {
+            if (executor.getWatchdog() != null && executor.getWatchdog().killedProcess()) {
+                throw new HabushuException("Process killed after timeout");
+            }
+            throw new HabushuException(e);
+        } catch (IOException e) {
+            throw new HabushuException(e);
+        }
     }
 
     private CommandLine createCommandLine(List<String> command) {
-	CommandLine commmandLine = new CommandLine(command.get(0));
+        CommandLine commmandLine = new CommandLine(command.get(0));
 
-	for (int i = 1; i < command.size(); i++) {
-	    String argument = command.get(i);
-	    commmandLine.addArgument(argument, false);
-	}
+        for (int i = 1; i < command.size(); i++) {
+            String argument = command.get(i);
+            commmandLine.addArgument(argument, false);
+        }
 
-	return commmandLine;
+        return commmandLine;
     }
 
     private Map<String, String> createEnvironment(final List<String> paths, final Platform platform,
-	    final Map<String, String> additionalEnvironment) {
-	final Map<String, String> environment = new HashMap<>(System.getenv());
+                                                  final Map<String, String> additionalEnvironment) {
+        final Map<String, String> environment = new HashMap<>(System.getenv());
 
-	if (additionalEnvironment != null) {
-	    environment.putAll(additionalEnvironment);
-	}
+        if (additionalEnvironment != null) {
+            environment.putAll(additionalEnvironment);
+        }
 
-	if (platform.isWindows()) {
-	    for (final Map.Entry<String, String> entry : environment.entrySet()) {
-		final String pathName = entry.getKey();
-		if (PATH_ENV_VAR.equalsIgnoreCase(pathName)) {
-		    final String pathValue = entry.getValue();
-		    environment.put(pathName, extendPathVariable(pathValue, paths));
-		}
-	    }
-	} else {
-	    final String pathValue = environment.get(PATH_ENV_VAR);
-	    environment.put(PATH_ENV_VAR, extendPathVariable(pathValue, paths));
-	}
+        if (platform.isWindows()) {
+            for (final Map.Entry<String, String> entry : environment.entrySet()) {
+                final String pathName = entry.getKey();
+                if (PATH_ENV_VAR.equalsIgnoreCase(pathName)) {
+                    final String pathValue = entry.getValue();
+                    environment.put(pathName, extendPathVariable(pathValue, paths));
+                }
+            }
+        } else {
+            final String pathValue = environment.get(PATH_ENV_VAR);
+            environment.put(PATH_ENV_VAR, extendPathVariable(pathValue, paths));
+        }
 
-	return environment;
+        return environment;
     }
 
     private String extendPathVariable(final String existingValue, final List<String> paths) {
-	final StringBuilder pathBuilder = new StringBuilder();
-	for (final String path : paths) {
-	    pathBuilder.append(path).append(File.pathSeparator);
-	}
-	if (existingValue != null) {
-	    pathBuilder.append(existingValue).append(File.pathSeparator);
-	}
-	return pathBuilder.toString();
+        final StringBuilder pathBuilder = new StringBuilder();
+        for (final String path : paths) {
+            pathBuilder.append(path).append(File.pathSeparator);
+        }
+        if (existingValue != null) {
+            pathBuilder.append(existingValue).append(File.pathSeparator);
+        }
+        return pathBuilder.toString();
     }
 
     private Executor createExecutor(File workingDirectory, long timeoutInSeconds) {
-	DefaultExecutor executor = new DefaultExecutor();
-	executor.setWorkingDirectory(workingDirectory);
-	executor.setProcessDestroyer(new ShutdownHookProcessDestroyer()); // Fixes #41
+        DefaultExecutor executor = new DefaultExecutor();
+        executor.setWorkingDirectory(workingDirectory);
+        executor.setProcessDestroyer(new ShutdownHookProcessDestroyer()); // Fixes #41
 
-	if (timeoutInSeconds > 0) {
-	    executor.setWatchdog(new ExecuteWatchdog(timeoutInSeconds * 1000));
-	}
+        if (timeoutInSeconds > 0) {
+            executor.setWatchdog(new ExecuteWatchdog(timeoutInSeconds * 1000));
+        }
 
-	return executor;
+        return executor;
     }
 
     private static class LoggerOutputStream extends LogOutputStream {
-	private final Logger logger;
+        private final Logger logger;
 
-	LoggerOutputStream(Logger logger, int logLevel) {
-	    super(logLevel);
-	    this.logger = logger;
-	}
+        LoggerOutputStream(Logger logger, int logLevel) {
+            super(logLevel);
+            this.logger = logger;
+        }
 
-	@Override
-	public final void flush() {
-	    // buffer processing on close() only
-	}
+        @Override
+        public final void flush() {
+            // buffer processing on close() only
+        }
 
-	@Override
-	protected void processLine(final String line, final int logLevel) {
-	    logger.info(line);
-	}
+        @Override
+        protected void processLine(final String line, final int logLevel) {
+            logger.info(line);
+        }
     }
 
     /**
      * Helper method that logs the given process output at the error level if its
      * content is not blank.
-     * 
+     *
      * @param output
      * @param logger
      */
     protected void displayProcessOutputForException(ByteArrayOutputStream output, Logger logger) {
-	String outputAsStr = output.toString();
-	if (StringUtils.isNotBlank(outputAsStr)) {
-	    logger.error(outputAsStr);
-	}
+        String outputAsStr = output.toString();
+        if (StringUtils.isNotBlank(outputAsStr)) {
+            logger.error(outputAsStr);
+        }
     }
 }


### PR DESCRIPTION
Skips execution of Mojos if the packaging type isn't "habushu". Also adds the value of the PATH environment variable to the debug output of `ProcessExecutor`.

Fixes #54 