### PR TITLE
#77 - Moving cacheWheels config implementation to INSTALL phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,7 +653,7 @@ Uses [behave](https://github.com/behave/behave) to execute BDD scenarios that ar
 Builds the `sdist` and `wheel` archives of this project using `poetry build`. It also generates a `requirements.txt` file which is useful when installing the package in a Docker container where you may want to install the dependencies in a specific Docker layer to optimize caching.
 
 ##### install #####
-Publishes the `pom.xml` for the module into your local Maven Repository (`~/.m2/repository`).
+Publishes the `pom.xml` for the module into your local Maven Repository (`~/.m2/repository`). If the **cacheWheels** configuration is set to True, the `wheel` archive will be copied to the poetry cache directory (`~/{poetry-cache-dir}/cache/repositories/wheels/{artifact-id}/`). The **cacheWheels** configuration default behavior is not to cache the `wheel` archive.
 
 ##### deploy #####
 

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/BuildDeploymentArtifactsMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/BuildDeploymentArtifactsMojo.java
@@ -127,10 +127,6 @@ public class BuildDeploymentArtifactsMojo extends AbstractHabushuMojo {
 
             setUpPlaceholderFileAsMavenArtifact();
         }
-
-        if(cacheWheels){
-            cacheWheelFile();
-        }
     }
 
     private void logLocalMonorepoCaveats() {
@@ -166,27 +162,5 @@ public class BuildDeploymentArtifactsMojo extends AbstractHabushuMojo {
         }
 
         project.getArtifact().setFile(mavenArtifactFile);
-    }
-
-    private void cacheWheelFile() {
-        PoetryCommandHelper poetryHelper = createPoetryCommandHelper();
-        try{
-            File wheelSourceDirectory = new File(project.getBuild().getDirectory());
-            String poetryCacheDirectoryPath = poetryHelper.getPoetryCacheDirectoryPath();
-            File poetryWheelCacheDirectory = new File(String.format("%s/cache/repositories/wheels/%s", poetryCacheDirectoryPath, project.getArtifactId()));
-            //conditional will throw an error if cache directory isn't created 
-            if(poetryWheelCacheDirectory.exists() || poetryWheelCacheDirectory.mkdirs()){
-                List<File> wheelFiles = Stream.of(wheelSourceDirectory.listFiles())
-                                              .filter(file -> file.getAbsolutePath().endsWith(".whl"))
-                                              .map(File::getAbsoluteFile)
-                                              .collect(Collectors.toList());
-                for(File file : wheelFiles){
-                    HabushuUtil.copyFile(file.getPath(), String.format("%s/%s", poetryWheelCacheDirectory.toPath().toString(), file.getName()));
-                    getLog().info(String.format("Cached the %s file", file.getName()));
-                }
-            }
-        } catch (Exception e){
-            throw new HabushuException("Could not cache the " + project.getArtifactId() + " wheel file(s)!", e);
-        }
-    }    
+    }  
 }

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/CacheWheelsMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/CacheWheelsMojo.java
@@ -1,0 +1,54 @@
+package org.technologybrewery.habushu;
+
+import java.io.File;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.technologybrewery.habushu.exec.PoetryCommandHelper;
+import org.technologybrewery.habushu.util.HabushuUtil;
+
+/**
+ * Caches the generated poetry Wheel file when the
+ * {@link cacheWheels} flag configuration is set to 
+ * true during the {@link LifecyclePhase#INSTALL} 
+ * build phase.
+ * By default, the {@link cacheWheels} flag is set 
+ * to false and will not cache the wheel files. 
+ */
+@Mojo(name = "cache-wheels", defaultPhase = LifecyclePhase.INSTALL)
+public class CacheWheelsMojo extends AbstractHabushuMojo {
+
+    @Parameter(property = "habushu.cacheWheels", required = false, defaultValue = "false")
+    protected boolean cacheWheels;
+
+    @Override
+    public void doExecute() throws MojoExecutionException, MojoFailureException {
+        if(cacheWheels){
+            PoetryCommandHelper poetryHelper = createPoetryCommandHelper();
+            try{
+                File wheelSourceDirectory = new File(project.getBuild().getDirectory());
+                String poetryCacheDirectoryPath = poetryHelper.getPoetryCacheDirectoryPath();
+                File poetryWheelCacheDirectory = new File(String.format("%s/cache/repositories/wheels/%s", poetryCacheDirectoryPath, project.getArtifactId()));
+                //conditional will throw an error if cache directory isn't created 
+                if(poetryWheelCacheDirectory.exists() || poetryWheelCacheDirectory.mkdirs()){
+                    List<File> wheelFiles = Stream.of(wheelSourceDirectory.listFiles())
+                                                .filter(file -> file.getAbsolutePath().endsWith(".whl"))
+                                                .map(File::getAbsoluteFile)
+                                                .collect(Collectors.toList());
+                    for(File file : wheelFiles){
+                        HabushuUtil.copyFile(file.getPath(), String.format("%s/%s", poetryWheelCacheDirectory.toPath().toString(), file.getName()));
+                        getLog().info(String.format("Cached the %s file", file.getName()));
+                    }
+                }
+            } catch (Exception e){
+                throw new HabushuException("Could not cache the " + project.getArtifactId() + " wheel file(s)!", e);
+            }
+        }
+    }    
+}

--- a/habushu-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/habushu-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -22,7 +22,10 @@
 							<process-classes>org.technologybrewery.habushu:habushu-maven-plugin:${project.version}:format-python</process-classes>
 							<test>org.technologybrewery.habushu:habushu-maven-plugin:${project.version}:behave-bdd-test</test>
 							<package>org.technologybrewery.habushu:habushu-maven-plugin:${project.version}:build-deployment-artifacts</package>
-							<install>org.apache.maven.plugins:maven-install-plugin:install</install>
+							<install>
+								org.technologybrewery.habushu:habushu-maven-plugin:${project.version}:cache-wheels,
+								org.apache.maven.plugins:maven-install-plugin:install
+							</install>
 							<deploy>
 								org.technologybrewery.habushu:habushu-maven-plugin:${project.version}:publish-to-pypi-repo,
 								org.apache.maven.plugins:maven-deploy-plugin:deploy

--- a/habushu-mixology/pom.xml
+++ b/habushu-mixology/pom.xml
@@ -67,9 +67,6 @@
             <plugin>
                 <groupId>org.technologybrewery.habushu</groupId>
                 <artifactId>habushu-maven-plugin</artifactId>
-                <configuration>
-                    <cacheWheels>true</cacheWheels>
-                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
As a Habushu user, I want to be able to have my wheels installed to the local cache separately from the package step, so I have more control over the build lifecycle.

**Goal**

To add more control over the new cacheWheels habushu-maven-plugin configuration.

**Testing Approach**

Configure the Habushu-Mixology project to use the cacheWheels configuration and confirm the wheel is cached as expected during the Install lifecycle phase. 

**Solution details**

Creating a new cacheWheelsMojo that will execute during the install phase.

**Testing Steps**

Test 1: Confirm Habushu-Mixology builds as expected when cacheWheels is set to true.

1. Clone Habushu

```
mkdir habushu
git clone https://github.com/TechnologyBrewery/habushu.git habushu
```
2. In order to test this change we will need to invoke the new configuration: cacheWheels:boolean. Testing this change against the habushu/habushu-mixology/pom.xml's implementation of the habushu-maven-plugin. 

Set cacheWheels to TRUE : Expect the wheel file to be added to the poetry cache location; post build. 
 

```
<plugins> 
  <plugin> 
    <groupId>org.technologybrewery.habushu</groupId> 
    <artifactId>habushu-maven-plugin</artifactId> 
      <configuration> 
         <cacheWheels>true</cacheWheels> 
      </configuration> 
  </plugin> 
</plugins>
```
3. Run/Build Habushu

```
mvn clean install -Pbootstrap 
mvn clean install -pl :habushu-mixology -Dmaven.build.cache.enabled=false
``` 
4. Confirm the habushu-mixology wheel file is in the poetry cache directory
expected directory location: ${poetry-cache-dir}/cache/repositories/wheels/${artifact-id}/
the follow command finds your local cache directory. 

`poetry config cache-dir`
Test 2: Confirm Habushu-Mixology builds as expected with no configuration set.

1. Clear poetry cache
(this clears out previous run's cache results)

`poetry cache clear --all . `
 

2. Testing no configuration to confirm default behavior; expect no caching of wheel

Remove configuration completely : Expect the wheel file NOT to be added to the poetry cache location post build. 

```
<plugins> 
  <plugin> 
    <groupId>org.technologybrewery.habushu</groupId> 
    <artifactId>habushu-maven-plugin</artifactId>
  </plugin> 
</plugins>
```
3. Run/Build Habushu to test the new configuration. 

`mvn clean install -pl :habushu-mixology -Dmaven.build.cache.enabled=false `
4. Expect the wheel file NOT to be added to the poetry cache location post build. 

Test 3: Confirm Habushu-Mixology builds as expected when cacheWheels is set to false.
1. Testing the configuration false setting

Set cacheWheels to FALSE : Expect the wheel file NOT to be added to the poetry cache location post build. 

```
<plugins> 
  <plugin> 
    <groupId>org.technologybrewery.habushu</groupId> 
    <artifactId>habushu-maven-plugin</artifactId> 
      <configuration> 
         <cacheWheels>false</cacheWheels> 
      </configuration> 
  </plugin> 
</plugins>
```
2. Clear poetry cache
(this clears out previous run's cache results)

`poetry cache clear --all . `
3. Run/Build Habushu to test the new configuration. 

`mvn clean install -pl :habushu-mixology -Dmaven.build.cache.enabled=false `
4. Confirm the habushu-mixology wheel file is NOT in the poetry cache directory
expected directory location: ${poetry-cache-dir}/cache/repositories/wheels/${artifact-id}/
the follow command finds your local cache directory. 

`poetry config cache-dir`