### PR TITLE
Fix poetry-core migration failure for projects not using major.minor.patch version references

### DIFF
--- a/habushu-maven-plugin/pom.xml
+++ b/habushu-maven-plugin/pom.xml
@@ -40,6 +40,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.vdurmont</groupId>
+            <artifactId>semver4j</artifactId>
+            <version>3.1.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
             <version>3.4.1</version>

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/migration/CustomPoetrycoreVersionMigration.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/migration/CustomPoetrycoreVersionMigration.java
@@ -3,6 +3,8 @@ package org.technologybrewery.habushu.migration;
 import com.electronwill.nightconfig.core.CommentedConfig;
 import com.electronwill.nightconfig.core.Config;
 import com.electronwill.nightconfig.core.file.FileConfig;
+import com.vdurmont.semver4j.Semver;
+import com.vdurmont.semver4j.Semver.SemverType;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,6 +22,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 
 /**
@@ -32,11 +36,9 @@ import java.util.Optional;
 public class CustomPoetrycoreVersionMigration extends AbstractMigration {
 
     public static final Logger logger = LoggerFactory.getLogger(CustomPoetrycoreVersionMigration.class);
-
     protected Map<String, TomlReplacementTuple> replacements = new HashMap<>();
-
-    private boolean isMajorVersionUpdateRequired;
-    private boolean isMinorVersionUpdateRequired;
+    private boolean isPoetryCoreVersionUpdateRequired;
+    private static final String POETRY_CORE_REQUIRED_VERSION = PoetryUtil.POETRY_CORE_VERSION_REQUIREMENT.substring(1);
 
     @Override
     protected boolean shouldExecuteOnFile(File file) {
@@ -47,8 +49,6 @@ public class CustomPoetrycoreVersionMigration extends AbstractMigration {
                 Config buildSystem = toolBuildSystem.get();
                 Map<String, Object> dependencyMap = buildSystem.valueMap();
                 for (Map.Entry<String, Object> dependency : dependencyMap.entrySet()) {
-                    isMajorVersionUpdateRequired = false;
-                    isMinorVersionUpdateRequired = false;
                     // check if we need to upgrade the poetry-core version.
                    if(isPoetrycoreUpgradeRequired(dependency)) {
                        return true;
@@ -65,40 +65,28 @@ public class CustomPoetrycoreVersionMigration extends AbstractMigration {
         try (BufferedReader reader = new BufferedReader(new FileReader(pyProjectTomlFile))) {
             String line = reader.readLine();
             while (line != null) {
-                boolean isEmptyLine = line.isBlank();
-
                 if (line.contains(StringUtils.SPACE) && line.contains(TomlUtils.EQUALS)) {
                     String key = line.substring(0, line.indexOf(StringUtils.SPACE));
                     if (key == null) {
                         key = line.substring(0, line.indexOf(TomlUtils.EQUALS));
-                    }
-
-                    if (key != null) {
+                    } else {
                         key = key.strip();
-
                         TomlReplacementTuple matchedTuple = replacements.get(key);
                         if ((matchedTuple != null) && (line.contains(TomlUtils.POETRY_CORE)) && (line.contains(TomlUtils.EQUALS))) {
-                            // update the poetry-core major version upgrade if required.
+                            // update the poetry-core version if required.
                             StringBuilder stringBuilder = new StringBuilder(line);
-                            if(isMajorVersionUpdateRequired){
-                                int majorIndex = line.lastIndexOf(TomlUtils.EQUALS) + 1;
-                                int endMajorIndex = line.indexOf(TomlUtils.DOT);
-                                String poetryCoreReqMajorVer = TomlUtils.getMajorReqVersion(PoetryUtil.POETRY_CORE_VERSION_REQUIREMENT);
-                                stringBuilder = stringBuilder.replace(majorIndex, endMajorIndex, poetryCoreReqMajorVer);
-                                line = stringBuilder.toString();
-                                logger.debug("Updating the Poetry-core major version to {}.", poetryCoreReqMajorVer);
-                            }
 
-                            // update the poetry-core minor version if required.
-                            if (isMinorVersionUpdateRequired) {
-                                int minorVersionIndex = line.indexOf(TomlUtils.DOT) + 1;
-                                int endMinorVersionIndex = line.lastIndexOf(TomlUtils.DOT);
-                                String poetryCoreReqMinorVersion = TomlUtils.getMinorReqVersion(PoetryUtil.POETRY_CORE_VERSION_REQUIREMENT);
-                                stringBuilder = stringBuilder.replace(minorVersionIndex, endMinorVersionIndex, poetryCoreReqMinorVersion);
-                                line = stringBuilder.toString();
-                                logger.debug("Updating the Poetry-core minor version to {}.", poetryCoreReqMinorVersion);
+                            if(isPoetryCoreVersionUpdateRequired){
+                                int versionIndex = line.lastIndexOf(TomlUtils.EQUALS) + 1;
+                                int endVersionIndex = line.lastIndexOf(TomlUtils.DOT) + 2;
+                                //This case will only occur when:
+                                // requires = ["poetry-core>=1"] where there is no dot after 1
+                                if(line.lastIndexOf(TomlUtils.DOT) == -1){
+                                    endVersionIndex = versionIndex + 1;
+                                }
+                                line = stringBuilder.replace(versionIndex, endVersionIndex, POETRY_CORE_REQUIRED_VERSION).toString();
+                                logger.info("Updating poetry-core version to {}.", POETRY_CORE_REQUIRED_VERSION);
                             }
-                            logger.info("Updated the Poetry-core version to {} required by Habushu.", PoetryUtil.POETRY_CORE_VERSION_REQUIREMENT);
                         }
                     }
                 }
@@ -119,44 +107,60 @@ public class CustomPoetrycoreVersionMigration extends AbstractMigration {
     }
 
     private boolean isPoetrycoreUpgradeRequired(Map.Entry<String, Object> dependency) {
-        replacements.clear();
         String packageName = dependency.getKey();
+        Semver poetryCoreSemVerWithPatch;
 
         if (packageName.equals(TomlUtils.REQUIRES)) {
             String dependencyVal = dependency.getValue().toString();
             if (dependencyVal.contains(TomlUtils.POETRY_CORE) && dependencyVal.contains(TomlUtils.EQUALS)) {
-                String poetrycoreVer = dependencyVal.substring(TomlUtils.getIndexOfFirstDigit(dependencyVal), TomlUtils.getIndexOfLastDigit(dependencyVal));
-                int endMajorVerIndex = poetrycoreVer.indexOf(TomlUtils.DOT);
-                int poetryCoreMajorVer = Integer.parseInt(poetrycoreVer.substring(0, endMajorVerIndex));
-                int poetryCoreReqMajorVersion =  Integer.parseInt(TomlUtils.getMajorReqVersion(PoetryUtil.POETRY_CORE_VERSION_REQUIREMENT));
+                String poetrycoreVerFromToml = dependencyVal.substring(TomlUtils.getIndexOfFirstDigit(dependencyVal), TomlUtils.getIndexOfLastDigit(dependencyVal));
+                String poetrycoreVer = formatSemVerString(poetrycoreVerFromToml);
+                Semver poetryCoreSemVer = new Semver(poetrycoreVerFromToml, SemverType.NPM);
+                Semver poetryCoreSemVerReqVersion =  new Semver(POETRY_CORE_REQUIRED_VERSION, SemverType.NPM);
 
-                // if the major version is less than required major version then return true.
-                if(poetryCoreMajorVer < poetryCoreReqMajorVersion) {
-                    isMajorVersionUpdateRequired = true;
-                    isMinorVersionUpdateRequired = true;
-                }
-
-                // Now check for the minor version. If the major version is equal to the required
-                // major version but if the minor version is less than the required minor version
-                // then upgrade for minor version is needed.
-                int minorVerIndex = poetrycoreVer.indexOf(TomlUtils.DOT) + 1;
-                int endMinorVerIndex = poetrycoreVer.lastIndexOf(TomlUtils.DOT);
-                int poetryCoreMinorVer = Integer.parseInt(poetrycoreVer.substring(minorVerIndex, endMinorVerIndex));
-                int poetryCoreReqMinorVersion = Integer.parseInt(TomlUtils.getMinorReqVersion(PoetryUtil.POETRY_CORE_VERSION_REQUIREMENT));
-
-                if ((poetryCoreMajorVer == poetryCoreReqMajorVersion && poetryCoreMinorVer < poetryCoreReqMinorVersion)) {
-                    isMinorVersionUpdateRequired = true;
-                }
-
-                // Return true if major or minor version upgarde is required.
-                if(isMajorVersionUpdateRequired || isMinorVersionUpdateRequired) {
-                    TomlReplacementTuple replacementTuple = new TomlReplacementTuple(packageName, poetrycoreVer, "poetry-core>=1.6.0");
+                if(poetryCoreSemVer.isLowerThan(poetryCoreSemVerReqVersion)){
+                    isPoetryCoreVersionUpdateRequired = true;
+                    TomlReplacementTuple replacementTuple = new TomlReplacementTuple(packageName, poetrycoreVer, getUpdatedOperatorAndVersion());
                     replacements.put(packageName, replacementTuple);
-                    logger.debug("Found build-system's Poetry-core version : {} less than the required version for Habushu. It will be updated to the required version of {}.", poetrycoreVer, PoetryUtil.POETRY_CORE_VERSION_REQUIREMENT);
+                    logger.info("Found build-system's poetry-core version : {} less than the required version for Habushu. It will be updated to the required version of {}.", poetrycoreVer, POETRY_CORE_REQUIRED_VERSION);
                     return true;
                 }
             }
         }
         return false;
     }
+
+    /**
+     * Converts a major.minor version to major.minor.patch version
+     * @param poetryCoreVer
+     * @return String formatted in semantic version format
+     */
+    private String formatSemVerString(String poetryCoreVer){
+
+        String formattedString = "0.0.0";
+
+        //Adding a zero if patch version is missing.
+        // Will be corrected to the right patch version in performMigration method
+        if (Pattern.matches("\\d", poetryCoreVer)) {
+            formattedString = poetryCoreVer + ".0.0";
+        } else if (Pattern.matches("\\d\\.\\d", poetryCoreVer)) {
+            formattedString = poetryCoreVer + ".0";
+        } else if (Pattern.matches("\\d\\.\\d\\.\\d", poetryCoreVer)) {
+            formattedString = poetryCoreVer;
+        }
+
+        return formattedString;
+    }
+
+    /**
+     * This method will the PoetryUtil POETRY_CORE_VERSION_REQUIREMENT to
+     * get the value and create an updatedOperatorAndVersion. Until this change
+     * it was being hard coded. Refactoring so only one change is needed in PoetryUtil
+     * when a new version is used
+     * @return a string of updatedOperatorAndVersion
+     */
+    private String getUpdatedOperatorAndVersion(){
+        return "poetry-core>="+POETRY_CORE_REQUIRED_VERSION;
+    }
+
 }

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/util/TomlUtils.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/util/TomlUtils.java
@@ -147,27 +147,4 @@ public final class TomlUtils {
         return lastDigitIndex;
     }
 
-    /**
-     * Finds and returns the minor version in a given version string.
-     *
-     * @param input version string
-     * @return the minor version.
-     */
-    public static String getMinorReqVersion(String version) {
-        int minorVerReqIndex = version.indexOf(TomlUtils.DOT) + 1;
-        int endMinorVerReqIndex = version.lastIndexOf(TomlUtils.DOT);
-        return version.substring(minorVerReqIndex, endMinorVerReqIndex);
-    }
-
-    /**
-     * Finds and returns the major version in a given version string.
-     *
-     * @param input version string
-     * @return the major version.
-     */
-    public static String getMajorReqVersion(String version) {
-        int majorVerReqIndex = getIndexOfFirstDigit(version);
-        int endMajorVerReqIndex = version.indexOf(TomlUtils.DOT);
-        return version.substring(majorVerReqIndex, endMajorVerReqIndex);
-    }
 }

--- a/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/migration/PoetrycoreVersionMigrationSteps.java
+++ b/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/migration/PoetrycoreVersionMigrationSteps.java
@@ -46,6 +46,16 @@ public class PoetrycoreVersionMigrationSteps {
         pyProjectToml = new File(testTomlFileDirectory, "with-poetry-core-version-2-0-0.toml");
     }
 
+    @Given("an existing pyproject.toml file with poetry-core version 1.5 in the build-system group")
+    public void an_existing_pyproject_toml_file_with_poetry_core_version_of_1_5_in_the_build_system_group() {
+        pyProjectToml = new File(testTomlFileDirectory, "with-poetry-core-version-1-5.toml");
+    }
+
+    @Given("an existing pyproject.toml file with poetry-core version 1.5.8 in the build-system group")
+    public void an_existing_pyproject_toml_file_with_poetry_core_version_of_1_5_8_in_the_build_system_group() {
+        pyProjectToml = new File(testTomlFileDirectory, "with-poetry-core-version-1-5-8.toml");
+    }
+
     @When("Habushu poetry core migration executes")
     public void habushu_migrations_execute() {
         CustomPoetrycoreVersionMigration migration = new CustomPoetrycoreVersionMigration();

--- a/habushu-maven-plugin/src/test/resources/migration/poetrycore/with-poetry-core-version-1-5-8.toml
+++ b/habushu-maven-plugin/src/test/resources/migration/poetrycore/with-poetry-core-version-1-5-8.toml
@@ -1,0 +1,22 @@
+[tool.poetry]
+name = "habushu_mixology"
+version = "2.9.0.dev"
+description = "Example of how to use the habushu-maven-plugin"
+authors = ["Eric Konieczny <ekoniec1@gmail.com>"]
+license = "MIT License"
+
+[tool.poetry.dependencies]
+python = "^3.11"
+krausening = "17"
+cryptography = "^41.0.3"
+uvicorn = {version = "^0.18.0", extras = ["standard"]}
+
+[tool.poetry.dev-dependencies]
+black = "^22.3.0"
+behave = "^1.2.6"
+grpcio-tools = "^1.48.0"
+python-dotenv = "^0.20.0"
+
+[build-system]
+requires = ["poetry-core>=1.5.8"]
+build-backend = "poetry.core.masonry.api"

--- a/habushu-maven-plugin/src/test/resources/migration/poetrycore/with-poetry-core-version-1-5.toml
+++ b/habushu-maven-plugin/src/test/resources/migration/poetrycore/with-poetry-core-version-1-5.toml
@@ -1,0 +1,22 @@
+[tool.poetry]
+name = "habushu_mixology"
+version = "2.9.0.dev"
+description = "Example of how to use the habushu-maven-plugin"
+authors = ["Eric Konieczny <ekoniec1@gmail.com>"]
+license = "MIT License"
+
+[tool.poetry.dependencies]
+python = "^3.11"
+krausening = "17"
+cryptography = "^41.0.3"
+uvicorn = {version = "^0.18.0", extras = ["standard"]}
+
+[tool.poetry.dev-dependencies]
+black = "^22.3.0"
+behave = "^1.2.6"
+grpcio-tools = "^1.48.0"
+python-dotenv = "^0.20.0"
+
+[build-system]
+requires = ["poetry-core>=1.5"]
+build-backend = "poetry.core.masonry.api"

--- a/habushu-maven-plugin/src/test/resources/specifications/poetry-core-version-migration.feature
+++ b/habushu-maven-plugin/src/test/resources/specifications/poetry-core-version-migration.feature
@@ -2,22 +2,32 @@ Feature: Poetry-core version migration
   Baton will migrate the poetry-core version within the pyproject.toml file to match the required version needed by the Habushu.
 
 
-Scenario: Migrate poetry-core version when existing poetry-core version is less than 1.6.0
-Given an existing pyproject.toml file with poetry-core version less than 1.6.0 in the build-system group
-When Habushu poetry core migration executes
-Then the poetry-core version is updated to 1.6.0 in the build-system group
+  Scenario: Migrate poetry-core version when existing poetry-core version is less than 1.6.0
+    Given an existing pyproject.toml file with poetry-core version less than 1.6.0 in the build-system group
+    When Habushu poetry core migration executes
+    Then the poetry-core version is updated to 1.6.0 in the build-system group
 
-Scenario: No migration will be performed when the poetry-core version is equal to 1.6.0
-Given an existing pyproject.toml file with poetry-core version of 1.6.0 in the build-system group
-When Habushu poetry core migration executes
-Then no update was performed for poetry-core version
+  Scenario: No migration will be performed when the poetry-core version is equal to 1.6.0
+    Given an existing pyproject.toml file with poetry-core version of 1.6.0 in the build-system group
+    When Habushu poetry core migration executes
+    Then no update was performed for poetry-core version
 
-Scenario: No migration will be performed when the poetry-core version of 1.7.0
-Given an existing pyproject.toml file with poetry-core version of 1.7.0 in the build-system group
-When Habushu poetry core migration executes
-Then no update was performed for poetry-core version
+  Scenario: No migration will be performed when the poetry-core version of 1.7.0
+    Given an existing pyproject.toml file with poetry-core version of 1.7.0 in the build-system group
+    When Habushu poetry core migration executes
+    Then no update was performed for poetry-core version
 
-Scenario: No migration will be performed when the poetry-core version of 2.0.0
-Given an existing pyproject.toml file with poetry-core version of 2.0.0 in the build-system group
-When Habushu poetry core migration executes
-Then no update was performed for poetry-core version
+  Scenario: No migration will be performed when the poetry-core version of 2.0.0
+    Given an existing pyproject.toml file with poetry-core version of 2.0.0 in the build-system group
+    When Habushu poetry core migration executes
+    Then no update was performed for poetry-core version
+
+  Scenario: Migrate poetry-core version when existing poetry-core version is 1.5
+    Given an existing pyproject.toml file with poetry-core version 1.5 in the build-system group
+    When Habushu poetry core migration executes
+    Then the poetry-core version is updated to 1.6.0 in the build-system group
+
+  Scenario: Migrate poetry-core version when existing poetry-core version is 1.5.8
+    Given an existing pyproject.toml file with poetry-core version 1.5.8 in the build-system group
+    When Habushu poetry core migration executes
+    Then the poetry-core version is updated to 1.6.0 in the build-system group


### PR DESCRIPTION
1) Fixed code to tackle the failure when the patch version is not present in the toml file
2) Added 2 BDD tests for the cases identified in this issue