### PR TITLE
#91 Behave test results should output a test results in the Cucumber reports JSON format

### DIFF
--- a/habushu-maven-plugin/pom.xml
+++ b/habushu-maven-plugin/pom.xml
@@ -187,6 +187,10 @@
                     </properties>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>net.masterthought</groupId>
+                <artifactId>maven-cucumber-reporting</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/BehaveBddTestMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/BehaveBddTestMojo.java
@@ -29,6 +29,7 @@ import java.util.List;
 public class BehaveBddTestMojo extends AbstractHabushuMojo {
 
     protected static final String BEHAVE_PACKAGE = "behave";
+    protected static final String BEHAVE_CUCUMBER_FORMATTER = "behave-cucumber-formatter";
 
     /**
      * Options that should be passed to the behave command. <b>NOTE:</b> If this
@@ -36,6 +37,20 @@ public class BehaveBddTestMojo extends AbstractHabushuMojo {
      */
     @Parameter(property = "habushu.behaveOptions", required = false)
     protected String behaveOptions;
+
+    /**
+     * By default, format Behave test results in a JSON compatible with Cucumber Reports plugin
+     */
+    @Parameter(property = "habushu.outputCucumberStyleTestReports", required = false, defaultValue = "true")
+    protected boolean outputCucumberStyleTestReports;
+
+    /**
+     * By default, Behave marks Scenarios and Features with skipped steps as failures in its reports even if the
+     * other test steps themselves pass. To match Cucumber's default logic, this setting will prevent capturing skipped
+     * tests if there are no failures.
+     */
+    @Parameter(property = "habushu.dontFailBehaveTestsWithSkippedTestSteps", required = false, defaultValue = "true")
+    protected boolean dontFailBehaveTestsWithSkippedTestSteps;
 
 
     /**
@@ -82,6 +97,17 @@ public class BehaveBddTestMojo extends AbstractHabushuMojo {
             List<String> executeBehaveTestArgs = new ArrayList<>();
             executeBehaveTestArgs
                     .addAll(Arrays.asList("run", BEHAVE_PACKAGE, getCanonicalPathForFile(behaveDirectory)));
+
+            if (outputCucumberStyleTestReports) {
+                poetryHelper.installDevelopmentDependency(BEHAVE_CUCUMBER_FORMATTER);
+                executeBehaveTestArgs.add("--format=behave_cucumber_formatter:PrettyCucumberJSONFormatter");
+                executeBehaveTestArgs.add("--outfile=dist/cucumber-reports/cucumber.json");
+            }
+
+            if (dontFailBehaveTestsWithSkippedTestSteps) {
+                executeBehaveTestArgs.add("--no-skipped");
+            }
+
 
             if (StringUtils.isNotEmpty(behaveOptions)) {
                 executeBehaveTestArgs.addAll(Arrays.asList(StringUtils.split(behaveOptions)));

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/BehaveBddTestMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/BehaveBddTestMojo.java
@@ -49,8 +49,8 @@ public class BehaveBddTestMojo extends AbstractHabushuMojo {
      * other test steps themselves pass. To match Cucumber's default logic, this setting will prevent capturing skipped
      * tests if there are no failures.
      */
-    @Parameter(property = "habushu.dontFailBehaveTestsWithSkippedTestSteps", required = false, defaultValue = "true")
-    protected boolean dontFailBehaveTestsWithSkippedTestSteps;
+    @Parameter(property = "habushu.omitSkippedTests", required = false, defaultValue = "true")
+    protected boolean omitSkippedTests;
 
 
     /**
@@ -104,7 +104,7 @@ public class BehaveBddTestMojo extends AbstractHabushuMojo {
                 executeBehaveTestArgs.add("--outfile=dist/cucumber-reports/cucumber.json");
             }
 
-            if (dontFailBehaveTestsWithSkippedTestSteps) {
+            if (omitSkippedTests) {
                 executeBehaveTestArgs.add("--no-skipped");
             }
 

--- a/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/ReportFormattingSteps.java
+++ b/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/ReportFormattingSteps.java
@@ -6,11 +6,11 @@ import io.cucumber.java.en.When;
 public class ReportFormattingSteps {
     @When("the Habushu project is built")
     public void the_habushu_project_is_built() {
-        // Manual
+        // Manual - test is dependent on files generated after Behave runs and cannot be automated
     }
 
     @Then("a Cucumber report file {string} exists")
     public void a_cucumber_report_file_exists(String string) {
-        // Manual
+        // Manual - test is dependent on files generated after Behave runs and cannot be automated
     }
 }

--- a/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/ReportFormattingSteps.java
+++ b/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/ReportFormattingSteps.java
@@ -1,0 +1,16 @@
+package org.technologybrewery.habushu;
+
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+
+public class ReportFormattingSteps {
+    @When("the Habushu project is built")
+    public void the_habushu_project_is_built() {
+        // Manual
+    }
+
+    @Then("a Cucumber report file {string} exists")
+    public void a_cucumber_report_file_exists(String string) {
+        // Manual
+    }
+}

--- a/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/TestSpecifications.java
+++ b/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/TestSpecifications.java
@@ -14,7 +14,6 @@ import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
 @IncludeEngines("cucumber")
 @SelectClasspathResource("specifications")
 @ExcludeTags("manual")
-@ConfigurationParameter(key = FILTER_TAGS_PROPERTY_NAME, value = "not manual")
 @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "org.technologybrewery.habushu")
 public class TestSpecifications {
 

--- a/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/TestSpecifications.java
+++ b/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/TestSpecifications.java
@@ -1,10 +1,8 @@
 package org.technologybrewery.habushu;
 
-import org.junit.platform.suite.api.ConfigurationParameter;
-import org.junit.platform.suite.api.IncludeEngines;
-import org.junit.platform.suite.api.SelectClasspathResource;
-import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.*;
 
+import static io.cucumber.junit.platform.engine.Constants.FILTER_TAGS_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
 
 /**
@@ -15,6 +13,8 @@ import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
 @Suite
 @IncludeEngines("cucumber")
 @SelectClasspathResource("specifications")
+@ExcludeTags("manual")
+@ConfigurationParameter(key = FILTER_TAGS_PROPERTY_NAME, value = "not manual")
 @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "org.technologybrewery.habushu")
 public class TestSpecifications {
 

--- a/habushu-maven-plugin/src/test/resources/base-test-pyproject.toml
+++ b/habushu-maven-plugin/src/test/resources/base-test-pyproject.toml
@@ -19,7 +19,7 @@ python-dotenv = "^0.20.0"
 uvicorn = {version = "^0.16.0", extras = ["standard"]}
 package-b = "1"
 local-dev-package-example-a = {path = "../local-dev-package-example-a", develop = true}
-behave-cucumber-formatter = "1.0.1"
+behave-cucumber-formatter = ">=1.0.1"
 
 [tool.poetry.group.custom.dependencies]
 packageFoo = "^1.0.0"

--- a/habushu-maven-plugin/src/test/resources/base-test-pyproject.toml
+++ b/habushu-maven-plugin/src/test/resources/base-test-pyproject.toml
@@ -19,6 +19,7 @@ python-dotenv = "^0.20.0"
 uvicorn = {version = "^0.16.0", extras = ["standard"]}
 package-b = "1"
 local-dev-package-example-a = {path = "../local-dev-package-example-a", develop = true}
+behave-cucumber-formatter = "1.0.1"
 
 [tool.poetry.group.custom.dependencies]
 packageFoo = "^1.0.0"

--- a/habushu-maven-plugin/src/test/resources/junit-platform.properties
+++ b/habushu-maven-plugin/src/test/resources/junit-platform.properties
@@ -1,6 +1,6 @@
 cucumber.publish.quiet=true
 cucumber.publish.enabled=false
 cucumber.glue=org.technologybrewery.habushu
-cucumber.filter.tags=~@manual
+cucumber.filter.tags=not manual
 cucumber.plugin=pretty,\
             json:target/cucumber-reports/cucumber.json

--- a/habushu-maven-plugin/src/test/resources/junit-platform.properties
+++ b/habushu-maven-plugin/src/test/resources/junit-platform.properties
@@ -1,2 +1,6 @@
 cucumber.publish.quiet=true
 cucumber.publish.enabled=false
+cucumber.glue=org.technologybrewery.habushu
+cucumber.filter.tags=~@manual
+cucumber.plugin=pretty,\
+            json:target/cucumber-reports/cucumber.json

--- a/habushu-maven-plugin/src/test/resources/specifications/dependency-management.feature
+++ b/habushu-maven-plugin/src/test/resources/specifications/dependency-management.feature
@@ -53,7 +53,7 @@ Feature: Test dependency management capabilities to help align package versions 
       | packageFooTest | ^1.2.7             |
       | packageBarTest | ^0.9.0             |
 
-  Scenario: Inactive managed dependencies are skipped
+  Scenario Outline: Inactive managed dependencies are skipped
     Given a Habushu configuration with a managed dependency of "<package>" and "<operatorAndVersion>"
     When Habushu executes
     Then the pyproject.toml file has updates
@@ -64,7 +64,7 @@ Feature: Test dependency management capabilities to help align package versions 
       | black      | ^23.3.0            |
       | packageFoo | ^1.1.0             |
 
-  Scenario: SNAPSHOT managed dependencies get corrected to dev dependencies by default with Poetry version 1.5.0 + (overridePackageVersion is true)
+  Scenario Outline: SNAPSHOT managed dependencies get corrected to dev dependencies by default with Poetry version 1.5.0 + (overridePackageVersion is true)
     Given a Habushu configuration with a managed dependency of "<package>" and "<operatorAndVersion>" and "<poetryVersion>"
     When Habushu executes
     Then the pyproject.toml file is updated to contain "<package>" and "<updatedOperatorAndVersion>"
@@ -74,7 +74,7 @@ Feature: Test dependency management capabilities to help align package versions 
       | package-a | 1.1.0-SNAPSHOT     | 1.1.0.*                   | 1.5.0         |
       | package-b | 2-SNAPSHOT         | 2.*                       | 1.6.0         |
 
-  Scenario: SHIM - SNAPSHOT managed dependencies get corrected to ^ dev dependencies with any Poetry version and a ^ in the version (overridePackageVersion is true)
+  Scenario Outline: SHIM - SNAPSHOT managed dependencies get corrected to ^ dev dependencies with any Poetry version and a ^ in the version (overridePackageVersion is true)
     Given a Habushu configuration with a managed dependency of "<package>" and "<operatorAndVersion>" and "<poetryVersion>"
     When Habushu executes
     Then the pyproject.toml file is updated to contain "<package>" and "<updatedOperatorAndVersion>"
@@ -86,7 +86,7 @@ Feature: Test dependency management capabilities to help align package versions 
       | package-a | ^3.3.0-SNAPSHOT    | ^3.3.0.dev                | 1.2.2         |
       | package-b | ^4-SNAPSHOT        | ^4.dev                    | 1.3.0         |
 
-  Scenario: SNAPSHOT managed dependencies do NOT get corrected to dev dependencies when overridePackageVersion is false
+  Scenario Outline: SNAPSHOT managed dependencies do NOT get corrected to dev dependencies when overridePackageVersion is false
     Given a Habushu configuration with a managed dependency of "<package>" and "<operatorAndVersion>"
     And replace development version is disabled
     When Habushu executes
@@ -97,7 +97,7 @@ Feature: Test dependency management capabilities to help align package versions 
       | package-a | 1.1.0-SNAPSHOT     |
       | package-b | 2-SNAPSHOT         |
 
-  Scenario: Skip altering local development versions when processing SNAPSHOT managed dependencies
+  Scenario Outline: Skip altering local development versions when processing SNAPSHOT managed dependencies
     Given a Habushu configuration with a managed dependency of "<package>" and "<operatorAndVersion>"
     When Habushu executes
     Then the pyproject.toml file has no updates

--- a/habushu-maven-plugin/src/test/resources/specifications/report-formatting.feature
+++ b/habushu-maven-plugin/src/test/resources/specifications/report-formatting.feature
@@ -1,0 +1,7 @@
+@manual
+Feature: Test that generated projects output test results in Cucumber reports format
+
+  Scenario: Generate a cucumber report through Behave
+    Given a Habushu configuration with no dependency management entries
+    When the Habushu project is built
+    Then a Cucumber report file "target/cucumber-reports/cucumber.json" exists

--- a/habushu-mixology-consumer/pom.xml
+++ b/habushu-mixology-consumer/pom.xml
@@ -41,6 +41,10 @@
                     </managedDependencies>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>net.masterthought</groupId>
+                <artifactId>maven-cucumber-reporting</artifactId>
+            </plugin>
         </plugins>
     </build>
 
@@ -68,6 +72,12 @@
             <artifactId>habushu-mixology</artifactId>
             <version>${project.version}</version>
             <type>habushu</type>
+        </dependency>
+        <dependency>
+            <groupId>net.masterthought</groupId>
+            <artifactId>cucumber-reporting</artifactId>
+            <version>${version.cucumber.reporting.plugin}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/habushu-mixology-consumer/pyproject.toml
+++ b/habushu-mixology-consumer/pyproject.toml
@@ -13,7 +13,7 @@ habushu-mixology = {path = "../habushu-mixology", develop = true}
 
 
 [tool.poetry.group.dev.dependencies]
-behave-cucumber-formatter = "^1.0.1"
+behave-cucumber-formatter = ">=1.0.1"
 
 [tool.poetry.dev-dependencies]
 black = "^23.3.0"

--- a/habushu-mixology-consumer/pyproject.toml
+++ b/habushu-mixology-consumer/pyproject.toml
@@ -11,6 +11,10 @@ python = "^3.11"
 [tool.poetry.group.monorepo.dependencies]
 habushu-mixology = {path = "../habushu-mixology", develop = true}
 
+
+[tool.poetry.group.dev.dependencies]
+behave-cucumber-formatter = "^1.0.1"
+
 [tool.poetry.dev-dependencies]
 black = "^23.3.0"
 behave = "^1.2.6"

--- a/habushu-mixology/pom.xml
+++ b/habushu-mixology/pom.xml
@@ -14,6 +14,15 @@
     <artifactId>habushu-mixology</artifactId>
     <packaging>habushu</packaging>
 
+    <dependencies>
+        <dependency>
+            <groupId>net.masterthought</groupId>
+            <artifactId>cucumber-reporting</artifactId>
+            <version>${version.cucumber.reporting.plugin}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
     <build>
         <directory>dist</directory>
         <pluginManagement>
@@ -67,6 +76,10 @@
             <plugin>
                 <groupId>org.technologybrewery.habushu</groupId>
                 <artifactId>habushu-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>net.masterthought</groupId>
+                <artifactId>maven-cucumber-reporting</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/habushu-mixology/pyproject.toml
+++ b/habushu-mixology/pyproject.toml
@@ -17,6 +17,9 @@ behave = "^1.2.6"
 grpcio-tools = "^1.48.0"
 python-dotenv = "^0.20.0"
 
+[tool.poetry.group.dev.dependencies]
+behave-cucumber-formatter = "^1.0.1"
+
 [build-system]
 requires = ["poetry-core>=1.6.0"]
 build-backend = "poetry.core.masonry.api"

--- a/habushu-mixology/pyproject.toml
+++ b/habushu-mixology/pyproject.toml
@@ -18,7 +18,7 @@ grpcio-tools = "^1.48.0"
 python-dotenv = "^0.20.0"
 
 [tool.poetry.group.dev.dependencies]
-behave-cucumber-formatter = "^1.0.1"
+behave-cucumber-formatter = ">=1.0.1"
 
 [build-system]
 requires = ["poetry-core>=1.6.0"]

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
 	<properties>
 		<!-- override parent POM until it is next upgrade (arguably, this property should not be in parent at all: -->
 		<version.python.default>3.11.4</version.python.default>
+		<version.cucumber.reporting.plugin>5.7.5</version.cucumber.reporting.plugin>
 	</properties>
 
 	<dependencyManagement>
@@ -68,6 +69,36 @@
 	</dependencyManagement>
 
 	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>net.masterthought</groupId>
+					<artifactId>maven-cucumber-reporting</artifactId>
+					<version>${version.cucumber.reporting.plugin}</version>
+					<executions>
+						<execution>
+							<id>execution</id>
+							<phase>verify</phase>
+							<goals>
+								<goal>generate</goal>
+							</goals>
+							<configuration>
+								<projectName>${project.artifactId}</projectName>
+								<skipEmptyJSONFiles>true</skipEmptyJSONFiles>
+								<checkBuildResult>true</checkBuildResult>
+								<treatUndefinedAsFailed>true</treatUndefinedAsFailed>
+								<treatSkippedAsFailed>false</treatSkippedAsFailed>
+								<outputDirectory>${project.build.directory}/cucumber-reports</outputDirectory>
+								<inputDirectory>${project.build.directory}/cucumber-reports</inputDirectory>
+								<jsonFiles>
+									<param>**/cucumber.json</param>
+								</jsonFiles>
+							</configuration>
+						</execution>
+					</executions>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 		<plugins>
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>


### PR DESCRIPTION
Causes the test outputs for Behave tests to be outputted to ~/target/cucumber-reports/cucumber.json in a format compatible with Cucumber reports. This creates more consistency between the Java Cucumber and Python Behave test suites.