### PR TITLE
#94 Modifying retrieve caching logic to allow for non-habushu packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,8 +554,8 @@ Default: `false`
 
 Optional set of wheel dependencies to retrieve from poetry cache. This allows previously cached external 
 wheel dependencies to be copied into a given target directory if it exists in poetry cache. This logic 
-depends on wheels to have first been cached by `cacheWheels` habushu-maven-plugin configuration. Warnings 
-will be logged if the specified wheel isn't found. 
+depends on wheels to have first been cached by `cacheWheels` habushu-maven-plugin configuration and executes
+during the VALIDATE maven phase. Warnings will be logged if the specified wheel isn't found. 
 ```xml
 <plugin>
 	<groupId>org.technologybrewery.habushu</groupId>
@@ -565,9 +565,9 @@ will be logged if the specified wheel isn't found.
 		<wheelDependencies>
 			<wheelDependency>
 				<artifactId>foundation-core-python</artifactId>
-				<tartgetDirectory>${project.build.directory}</tartgetDirectory>
+				<targetDirectory>${project.build.directory}</targetDirectory>
 			</wheelDependency>
-		</managedDependencies>
+		</wheelDependencies>
 		...
 	</configuration>
 </plugin>

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/RetrieveWheelsMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/RetrieveWheelsMojo.java
@@ -32,6 +32,9 @@ public class RetrieveWheelsMojo extends AbstractHabushuMojo {
     @Parameter(property = "habushu.wheelDependencies", required = false)
     protected List<WheelDependency> wheelDependencies;
 
+    /**
+    * Overriding to allow execution in non-habushu projects
+    */      
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         doExecute();

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/RetrieveWheelsMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/RetrieveWheelsMojo.java
@@ -33,6 +33,11 @@ public class RetrieveWheelsMojo extends AbstractHabushuMojo {
     protected List<WheelDependency> wheelDependencies;
 
     @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        doExecute();
+    }    
+
+    @Override
     public void doExecute() throws MojoExecutionException, MojoFailureException {
         if (!wheelDependencies.isEmpty()) {
             processWheelDependencies();


### PR DESCRIPTION
Currently the RetrieveWheels functionality requires that the executing packaging is Habushu, however, there are some use cases where we'd want to use these functionality in non-habushu packaging.