### PR TITLE
Change output directory for Behave tests

### DIFF
--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/BehaveBddTestMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/BehaveBddTestMojo.java
@@ -101,7 +101,7 @@ public class BehaveBddTestMojo extends AbstractHabushuMojo {
             if (outputCucumberStyleTestReports) {
                 poetryHelper.installDevelopmentDependency(BEHAVE_CUCUMBER_FORMATTER);
                 executeBehaveTestArgs.add("--format=behave_cucumber_formatter:PrettyCucumberJSONFormatter");
-                executeBehaveTestArgs.add("--outfile=dist/cucumber-reports/cucumber.json");
+                executeBehaveTestArgs.add("--outfile=target/cucumber-reports/cucumber.json");
             }
 
             if (omitSkippedTests) {

--- a/pom.xml
+++ b/pom.xml
@@ -88,8 +88,8 @@
 								<checkBuildResult>true</checkBuildResult>
 								<treatUndefinedAsFailed>true</treatUndefinedAsFailed>
 								<treatSkippedAsFailed>false</treatSkippedAsFailed>
-								<outputDirectory>${project.build.directory}/cucumber-reports</outputDirectory>
-								<inputDirectory>${project.build.directory}/cucumber-reports</inputDirectory>
+								<outputDirectory>${project.basedir}/target/cucumber-reports</outputDirectory>
+								<inputDirectory>${project.basedir}/target/cucumber-reports</inputDirectory>
 								<jsonFiles>
 									<param>**/cucumber.json</param>
 								</jsonFiles>


### PR DESCRIPTION
Configures Behave test JSONs and Cucumber-style reports to generate in the target directory rather than dist for consistent behavior across both testing frameworks.