### PR TITLE
HAB-release-git-config-issue-#110

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,9 +42,12 @@ jobs:
                   gpg-passphrase: GPG_PASSPHRASE
             - name: Release Habushu
               run: |
+                  git config --local user.email "habushu-noreply@technologybrewery.org"
+                  git config --local user.name "Github Actions"
                   chmod +x release-habushu.sh
                   ./release-habushu.sh ${{ inputs.releaseVersion }} ${{ inputs.developmentVersion }}
               env:
                   MAVEN_USERNAME: ${{ secrets.SONATYPE_CENTRAL_REPO_TOKEN_USER }}
                   MAVEN_PASSWORD: ${{ secrets.SONATYPE_CENTRAL_REPO_TOKEN_KEY }}
                   GPG_PASSPHRASE: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
     </developers>
 
     <scm>
-        <connection>scm:git:ssh://git@github.com/TechnologyBrewery/habushu.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/TechnologyBrewery/habushu.git</developerConnection>
+        <connection>scm:git:https://github.com/TechnologyBrewery/habushu.git</connection>
+        <developerConnection>scm:git:https://github.com/TechnologyBrewery/habushu.git</developerConnection>
         <url>https://github.com/TechnologyBrewery/habushu/</url>
         <tag>HEAD</tag>
     </scm>


### PR DESCRIPTION
- Updated scm to use https (instead of ssh) and authenticate with `GITHUB_TOKEN`
- Added Generic GitHub config information