### PR TITLE
Prepare release habushu 2.13.0 and Prepare for next development iteration

### DIFF
--- a/habushu-maven-plugin/pom.xml
+++ b/habushu-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.technologybrewery.habushu</groupId>
         <artifactId>habushu</artifactId>
-        <version>2.12.2-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
 
     <name>habushu::Maven Plugin for Python Projects</name>

--- a/habushu-maven-plugin/pom.xml
+++ b/habushu-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.technologybrewery.habushu</groupId>
         <artifactId>habushu</artifactId>
-        <version>2.13.0</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
 
     <name>habushu::Maven Plugin for Python Projects</name>

--- a/habushu-mixology-consumer/pom.xml
+++ b/habushu-mixology-consumer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.technologybrewery.habushu</groupId>
         <artifactId>habushu</artifactId>
-        <version>2.12.2-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
 
     <name>habushu::Mixing Drinks with Habushu Consumer</name>

--- a/habushu-mixology-consumer/pom.xml
+++ b/habushu-mixology-consumer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.technologybrewery.habushu</groupId>
         <artifactId>habushu</artifactId>
-        <version>2.13.0</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
 
     <name>habushu::Mixing Drinks with Habushu Consumer</name>

--- a/habushu-mixology-consumer/pyproject.toml
+++ b/habushu-mixology-consumer/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "habushu_mixology_consumer"
-version = "2.12.2.dev"
+version = "2.13.0"
 description = "Example of how to use the habushu-maven-plugin to consume other Habushu modules"
 authors = ["Eric Konieczny <ekoniec1@gmail.com>"]
 license = "MIT License"

--- a/habushu-mixology-consumer/pyproject.toml
+++ b/habushu-mixology-consumer/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "habushu_mixology_consumer"
-version = "2.13.0"
+version = "2.14.0.dev"
 description = "Example of how to use the habushu-maven-plugin to consume other Habushu modules"
 authors = ["Eric Konieczny <ekoniec1@gmail.com>"]
 license = "MIT License"

--- a/habushu-mixology/pom.xml
+++ b/habushu-mixology/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.technologybrewery.habushu</groupId>
         <artifactId>habushu</artifactId>
-        <version>2.12.2-SNAPSHOT</version>
+        <version>2.13.0</version>
     </parent>
 
     <name>habushu::Mixing Drinks with Habushu</name>

--- a/habushu-mixology/pom.xml
+++ b/habushu-mixology/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.technologybrewery.habushu</groupId>
         <artifactId>habushu</artifactId>
-        <version>2.13.0</version>
+        <version>2.14.0-SNAPSHOT</version>
     </parent>
 
     <name>habushu::Mixing Drinks with Habushu</name>

--- a/habushu-mixology/pyproject.toml
+++ b/habushu-mixology/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "habushu_mixology"
-version = "2.13.0"
+version = "2.14.0.dev"
 description = "Example of how to use the habushu-maven-plugin"
 authors = ["Eric Konieczny <ekoniec1@gmail.com>"]
 license = "MIT License"

--- a/habushu-mixology/pyproject.toml
+++ b/habushu-mixology/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "habushu_mixology"
-version = "2.12.2.dev"
+version = "2.13.0"
 description = "Example of how to use the habushu-maven-plugin"
 authors = ["Eric Konieczny <ekoniec1@gmail.com>"]
 license = "MIT License"

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <groupId>org.technologybrewery.habushu</groupId>
-    <version>2.12.2-SNAPSHOT</version>
+    <version>2.13.0</version>
     <artifactId>habushu</artifactId>
     <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <groupId>org.technologybrewery.habushu</groupId>
-    <version>2.13.0</version>
+    <version>2.14.0-SNAPSHOT</version>
     <artifactId>habushu</artifactId>
     <packaging>pom</packaging>
 


### PR DESCRIPTION
- Release 2.13.0 performed with Github Action
- Merging in next development iteration 2.14.0-SNAPSHOT

Release 2.13.0 available in Maven Central
![image](https://github.com/TechnologyBrewery/habushu/assets/163194595/e6e50bef-afb4-4382-b6be-71013e4bbaf9)
