### PR TITLE
#146 CI fix

### DIFF
--- a/habushu-maven-plugin/src/test/resources/containerize-dependencies/default-single-monorepo-dep/test-monorepo/extensions/extensions-monorepo-dep-consuming-application/pom.xml
+++ b/habushu-maven-plugin/src/test/resources/containerize-dependencies/default-single-monorepo-dep/test-monorepo/extensions/extensions-monorepo-dep-consuming-application/pom.xml
@@ -6,7 +6,7 @@
     <name>Extensions::Monorepo Dependency-Consuming Application</name>
     <groupId>org.test.monorepo</groupId>
     <artifactId>extensions-monorepo-dep-consuming-application</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0</version>
 
     <packaging>pom</packaging>
 
@@ -16,17 +16,12 @@
             <plugin>
                 <groupId>org.technologybrewery.habushu</groupId>
                 <artifactId>habushu-maven-plugin</artifactId>
-                <version>2.15.0</version>
+                <version>${project.version}</version>
             </plugin>
         </plugins>
     </build>
 
     <dependencies>
-        <dependency>
-            <groupId>org.technologybrewery.habushu</groupId>
-            <artifactId>habushu-maven-plugin</artifactId>
-            <version>2.15.0</version>
-        </dependency>
         <dependency>
             <groupId>org.test.monorepo</groupId>
             <artifactId>extensions-python-dep-X</artifactId>

--- a/habushu-maven-plugin/src/test/resources/containerize-dependencies/default-single-monorepo-dep/test-monorepo/extensions/extensions-python-dep-X/pom.xml
+++ b/habushu-maven-plugin/src/test/resources/containerize-dependencies/default-single-monorepo-dep/test-monorepo/extensions/extensions-python-dep-X/pom.xml
@@ -6,7 +6,7 @@
     <name>Extensions::Python Dependency X</name>
     <groupId>org.test.monorepo</groupId>
     <artifactId>extensions-python-dep-X</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0</version>
 
     <packaging>habushu</packaging>
 
@@ -15,18 +15,13 @@
             <plugin>
                 <groupId>org.technologybrewery.habushu</groupId>
                 <artifactId>habushu-maven-plugin</artifactId>
-                <version>2.15.0</version>
+                <version>${project.version}</version>
                 <extensions>true</extensions>
             </plugin>
         </plugins>
     </build>
 
     <dependencies>
-        <dependency>
-            <groupId>org.technologybrewery.habushu</groupId>
-            <artifactId>habushu-maven-plugin</artifactId>
-            <version>2.15.0</version>
-        </dependency>
         <dependency>
             <groupId>org.test.monorepo</groupId>
             <artifactId>foundation-python-dep-Y</artifactId>

--- a/habushu-maven-plugin/src/test/resources/containerize-dependencies/default-single-monorepo-dep/test-monorepo/extensions/extensions-python-dep-X/pyproject.toml
+++ b/habushu-maven-plugin/src/test/resources/containerize-dependencies/default-single-monorepo-dep/test-monorepo/extensions/extensions-python-dep-X/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "extensions-python-dep-X"
-version = "1.0.0.dev"
+version = "1.0.0"
 description = "description"
 authors = ["author"]
 packages = [

--- a/habushu-maven-plugin/src/test/resources/containerize-dependencies/default-single-monorepo-dep/test-monorepo/extensions/pom.xml
+++ b/habushu-maven-plugin/src/test/resources/containerize-dependencies/default-single-monorepo-dep/test-monorepo/extensions/pom.xml
@@ -6,7 +6,7 @@
     <name>Extensions</name>
     <groupId>org.test.monorepo</groupId>
     <artifactId>extensions</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0</version>
 
     <packaging>pom</packaging>
 

--- a/habushu-maven-plugin/src/test/resources/containerize-dependencies/default-single-monorepo-dep/test-monorepo/foundation/foundation-python-dep-Y/pom.xml
+++ b/habushu-maven-plugin/src/test/resources/containerize-dependencies/default-single-monorepo-dep/test-monorepo/foundation/foundation-python-dep-Y/pom.xml
@@ -6,7 +6,7 @@
     <name>Foundation::Python Dependency Y</name>
     <groupId>org.test.monorepo</groupId>
     <artifactId>foundation-python-dep-Y</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0</version>
 
     <packaging>habushu</packaging>
 
@@ -15,20 +15,10 @@
             <plugin>
                 <groupId>org.technologybrewery.habushu</groupId>
                 <artifactId>habushu-maven-plugin</artifactId>
-                <version>2.15.0</version>
+                <version>${project.version}</version>
                 <extensions>true</extensions>
             </plugin>
         </plugins>
     </build>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.technologybrewery.habushu</groupId>
-            <artifactId>habushu-maven-plugin</artifactId>
-            <version>2.15.0</version>
-        </dependency>
-    </dependencies>
-
-
 
 </project>

--- a/habushu-maven-plugin/src/test/resources/containerize-dependencies/default-single-monorepo-dep/test-monorepo/foundation/foundation-python-dep-Y/pyproject.toml
+++ b/habushu-maven-plugin/src/test/resources/containerize-dependencies/default-single-monorepo-dep/test-monorepo/foundation/foundation-python-dep-Y/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "extensions-python-dep-Y"
-version = "1.0.0.dev"
+version = "1.0.0"
 description = "description"
 authors = ["author"]
 packages = [

--- a/habushu-maven-plugin/src/test/resources/containerize-dependencies/default-single-monorepo-dep/test-monorepo/foundation/pom.xml
+++ b/habushu-maven-plugin/src/test/resources/containerize-dependencies/default-single-monorepo-dep/test-monorepo/foundation/pom.xml
@@ -6,7 +6,7 @@
     <name>Foundation</name>
     <groupId>org.test.monorepo</groupId>
     <artifactId>foundation</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0</version>
 
     <packaging>pom</packaging>
     

--- a/habushu-maven-plugin/src/test/resources/containerize-dependencies/default-single-monorepo-dep/test-monorepo/pom.xml
+++ b/habushu-maven-plugin/src/test/resources/containerize-dependencies/default-single-monorepo-dep/test-monorepo/pom.xml
@@ -6,7 +6,7 @@
     <name>Test Monorepo</name>
     <groupId>org.test.monorepo</groupId>
     <artifactId>test-monorepo</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0</version>
 
     <packaging>pom</packaging>
 


### PR DESCRIPTION
The previous commit with this issue broke CI due to the testing harness attempting to resolve the plugin dependencies when instantiating the mock build. This testing setup mirrors the testing setup with Fermenter more consistently and disables the plugin/dependency resolving (main fix).