### PR TITLE
#167 Simplify configuration of `containerize-dependencies` goal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ Thumbs.db
 
 # Local Poetry configuration
 poetry.toml
+!habushu-maven-plugin/src/test/resources/**/poetry.toml
 # https://python-poetry.org/docs/configuration/#virtualenvsin-project
 .venv
 /habushu-mixology/poetry.lock

--- a/README.md
+++ b/README.md
@@ -163,7 +163,17 @@ For example, developers may use this feature to bind a Habushu module's `compile
 ```
 
 ### Leveraging the containerize-dependencies Goal to Prepare a Containerized Virtual Environment ###
-If the execution is specified (does not run by default), the `containerize-dependencies` goal will collect a single `habushu` dependency specified the project's `pom.xml`, including all transitive habushu-packaged dependencies. After collecting the set of necessary dependencies, Habushu will copy the project files to the build directory under `containerize-support`, while preserving the original structure of the dependency modules to ensure that any path-based dependencies can be leveraged as-is. This directory can then be copied onto a Docker container and used to create a virtual environment capable of running the target Habushu project.
+The `containerize-dependencies` goal will collect a single `habushu` dependency specified in the project's `pom.xml`,
+including all transitive habushu-packaged dependencies. After collecting the set of necessary dependencies, Habushu will
+copy the project files for each dependency to a staging directory, while preserving the original structure of the
+dependency modules to ensure that any path-based dependencies can be leveraged as-is. This directory can then be copied
+onto a Docker container and used to create a virtual environment capable of running the target Habushu project.
+
+The plugin will automatically inject logic for building and using this virtual environment into a pre-existing Dockerfile
+by default. The `dockerfile` configuration must be set to the target Dockerfile. To disable the Dockerfile update
+altogether, set the `updateDockerfile` configuration to `false`. Because the final image must match the image that builds
+the virtual environment, Habushu must know what the base image for the final output should be. By default, `python:3.11-slim`
+is used, but this can be customized with the `dockerBase` and `dockerUser` configurations.
 
 ```xml
 <plugin>
@@ -172,7 +182,6 @@ If the execution is specified (does not run by default), the `containerize-depen
     <executions>
         <execution>
             <id>containerize-deps</id>
-            <phase>package</phase>
             <goals>
                 <goal>containerize-dependencies</goal>
             </goals>
@@ -185,25 +194,23 @@ If the execution is specified (does not run by default), the `containerize-depen
 ```
 
 
-To update the `Dockerfile` with logic to containerize the python application, specify the `Dockerfile` location by adding the `dockerfile` tag under `configuration`. To control exact insertion location use the `#HABUSHU_BUILDER_STAGE` and `#HABUSHU_FINAL_STAGE` tags in the `Dockerfile` in the preferred location.
-To disable Dockerfile update, set the `updateDockerfile` configuration to `false`.
-
-The `#HABUSHU_BUILDER_STAGE` tag will be replaced with the habushu builder stage logic to, first, copy the generated dependencies files onto a Docker container and then to create the virtual environment for building the specified habushu module.
-
-The `#HABUSHU_FINAL_STAGE` tag will be replaced with the habushu final stage logic to copy over the built virtual environment to the final stage.
+To control the exact insertion location of the Dockerfile build logic, use the `#HABUSHU_BUILDER_STAGE`and
+`#HABUSHU_FINAL_STAGE` comment tags in the `Dockerfile` in the preferred location. The `#HABUSHU_BUILDER_STAGE` tag will
+be replaced with the builder stage logic to copy the generated dependencies files onto a Docker container and then create
+the virtual environment by building the target Habushu project. The `#HABUSHU_FINAL_STAGE` tag will be replaced with the
+final stage logic to copy over the built virtual environment to the final Docker build stage.
 ```dockerfile
 #HABUSHU_BUILDER_STAGE
 
-FROM redhat/ubi9-minimal:latest
+FROM redhat/ubi9-minimal:latest AS builder
 RUN microdnf install -y python3.11
 
 #HABUSHU_FINAL_STAGE
 
-ENTRYPOINT ["/venv/bin/python3.11", "-m", "pets.main", "--enable_docs_url", "True"]
+ENTRYPOINT ["/opt/venv/bin/python3.11", "-m", "pets.main", "--enable_docs_url", "True"]
 ```
 
 The plugin will only examine dependencies that are of the type `habushu` in the dependencies block of the `pom.xml` file.
-
 ```xml
 <dependencies>
     <dependency>
@@ -214,8 +221,7 @@ The plugin will only examine dependencies that are of the type `habushu` in the 
     </dependency>
 </dependencies>
 ```
-
-Any transitive monorepo dependencie shoud also use this convention to ensure they are captured by the plugin.
+Any transitive monorepo dependencies should also use this convention to ensure they are captured by the plugin.
 
 ### Leveraging Maven Build Cache for Faster Builds ###
 
@@ -909,37 +915,7 @@ Controls whether the build will continue if lint identifies code that violate ch
 
 Default: `true`
 
-#### workingDirectoryRelativeToBasedir ####
-
-Controls the working directory relative to the `${project.basedir}` when examining monorepo dependency modules for copying source files with the `containerize-dependencies` goal. The working directory should be the `${project.basedir}`, hence the `null` default.
-
-Note: this parameter should be consistent with the `workingDirectory` configuration, such that both parameters point to the same expected working directory. For example, if the `workingDirectory` was overriden to `${project.basedir}/custom-workdir`, then `workingDirectoryRelativeToBasedir` should be set to `/custom-workdir`. Setting this parameter should only be necessary if a non-default `workingDirectory` configuration was set.
-
-Default: `null`
-
-#### distDirectoryRelativeToBasedir ####
-
-Controls the expected dist directory relative to the `${project.basedir}` when examining monorepo dependency modules for copying source files with the `containerize-dependencies` goal.
-
-Note: this parameter should be consistent with the `distDirectory` configuration. For example, if the `distDirectory` was set to `${project.basedir}/custom-dist`, then `distDirectoryRelativeToBasedir` should be set to `/custom-dist`. Setting this parameter should only be necessary if a non-default `distDirectory` configuration was set.
-
-Default: `/dist`
-
-#### targetDirectoryRelativeToBasedir ####
-
-Controls the expected target directory relative to the `${project.build.directory}` when examining monorepo dependency modules for copying source files with the `containerize-dependencies` goal.
-
-Note: this parameter should be consistent with the `targetDirectory` configuration. For example, if the `targetDirectory` was overriden to `${project.basedir}/custom-target`, then `targetDirectoryRelativeToBasedir` should be set to `/custom-target`. Setting this parameter should only be necessary if a non-default `targetDirectory` configuration was set.
-
-Default: `/target`
-
-#### anchorSourceDirectory ####
-
-Controls the directory of where containerization files will be copied from with the `containerize-dependencies` goal. If set, this value should be a directory path that houses all the necessary monorepo dependency Habushu modules (including transitive monorepo dependency modules). Additionally, if set, this path should either be an absolute path or a path relative to the `${project.basedir}` of the `containerize-dependencies` goal's execution. Typically, it is not recommended to set this parameter, as the default directory will be sufficient for monorepo use-cases.
-
-Default: the build's execution root directory
-
-#### containerizeSupportDirectory ####
+#### stagingDirectory ####
 
 Controls the location of where containerization files will be copied to as part of the `containerize-dependencies` goal.
 
@@ -953,7 +929,7 @@ Default: `true`
 
 #### dockerfile ####
 
-The Dockerfile to update with containerization logic during the `containerize-dependencies` goal. This must be set if the `updateDockerfile` is set to `true`
+The Dockerfile to update with containerization logic during the `containerize-dependencies` goal. This must be set if the `updateDockerfile` is set to `true`.
 
 Default: None
 

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/ContainerizeDepsMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/ContainerizeDepsMojo.java
@@ -13,7 +13,6 @@ import org.apache.maven.shared.model.fileset.FileSet;
 import org.apache.maven.shared.model.fileset.util.FileSetManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.technologybrewery.habushu.util.HabushuUtil;
 import org.technologybrewery.habushu.util.ContainerizeDepsDockerfileHelper;
 
 import java.io.File;
@@ -22,8 +21,6 @@ import java.io.IOException;
 import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -32,7 +29,7 @@ import java.util.stream.Collectors;
  * to the target directory along with the source files of
  * any transitive path-based dependencies.
  */
-@Mojo(name = "containerize-dependencies", defaultPhase = LifecyclePhase.PACKAGE)
+@Mojo(name = "containerize-dependencies", defaultPhase = LifecyclePhase.PREPARE_PACKAGE)
 public class ContainerizeDepsMojo extends AbstractHabushuMojo {
 
     private static final Logger logger = LoggerFactory.getLogger(ContainerizeDepsMojo.class);
@@ -41,93 +38,57 @@ public class ContainerizeDepsMojo extends AbstractHabushuMojo {
     protected MavenSession session;
 
     /**
-     * The desired version of Python to use.
+     * The directory in which the collected Python project files will be staged for containerization.
      */
-    @Parameter(defaultValue = PyenvAndPoetrySetup.PYTHON_DEFAULT_VERSION_REQUIREMENT, property = "habushu.pythonVersion")
-    protected String pythonVersion;
+    @Parameter(defaultValue = "${project.build.directory}/containerize-support", property = "habushu.stagingDirectory")
+    protected File stagingDirectory;
 
     /**
-     * Should Habushu use pyenv to manage the utilized version of Python?
+     * For each Python project that is identified as required for containerization, the files identified by this fileset
+     * will be copied to the staging directory. It is not currently possible to define different filesets for different
+     * projects. If not set, defaults to "{habushu.sourceDirectory}/**", "pyproject.toml", "poetry.toml", "poetry.lock"
+     * and "README.md".
      */
-    @Parameter(defaultValue = "true", property = "habushu.usePyenv")
-    protected boolean usePyenv;
+    @Parameter
+    protected FileSet defaultSourceSet;
 
     /**
-     * Indicates whether Habushu should leverage the
-     * {@code poetry-monorepo-dependency-plugin} to rewrite any local path
-     * dependencies (to other Poetry projects) as versioned packaged dependencies in
-     * generated wheel/sdist archives. If {@code true}, Habushu will replace
-     * invocations of Poetry's {@code build} and {@code publish} commands in the
-     * {@link BuildDeploymentArtifactsMojo} and {@link PublishToPyPiRepoMojo} with
-     * the extensions of those commands exposed by the
-     * {@code poetry monorepo-dependency-plugin}, which are
-     * {@code build-rewrite-path-deps} and {@code publish-rewrite-path-deps}
-     * respectively.
-     * <p>
-     * Typically, this flag will only be {@code true} when deploying/releasing
-     * Habushu modules within a CI environment that are part of a monorepo project
-     * structure which multiple Poetry projects depend on one another.
-     */
-    @Parameter(defaultValue = "false", property = "habushu.rewriteLocalPathDepsInArchives")
-    protected boolean rewriteLocalPathDepsInArchives;
-
-    /**
-     * File specifying the location of a generated shell script that will attempt to
-     * install the specified version of Python using "pyenv install --patch" with a
-     * patch that attempts to resolve the expected compilation error.
-     */
-    @Parameter(defaultValue = "pyenv-patch-install-python-version.sh", readonly = true)
-    private String patchInstallScriptRelativeToBuildDirectory;
-
-    /**
-     * Working directory relative to the basedir - typically working directory and basedir are synonymous.
-     */
-    @Parameter(readonly = true)
-    protected String workingDirectoryRelativeToBasedir;
-
-    /**
-     * Expected subdirectory of the monorepo dependency's basedir
-     * in which Poetry places generated source and wheel archive distributions.
-     */
-    @Parameter(defaultValue = "/dist", readonly = true)
-    protected String distDirectoryRelativeToBasedir;
-
-    /**
-     * Expected subdirectory of the monorepo dependency's basedir
-     * in which Maven places build-time artifacts. Should NOT include dist items.
-     */
-    @Parameter(defaultValue = "/target", readonly = true)
-    protected String targetDirectoryRelativeToBasedir;
-
-    /**
-     * Location of where containerization files will be placed.
-     */
-    @Parameter(defaultValue = "${project.build.directory}/containerize-support", readonly = true)
-    protected String containerizeSupportDirectory;
-
-    /**
-     * Upstream directory that houses all necessary monorepo dependencies.
-     * Monorepo dependency source files will be copied from here.
-     */
-    @Parameter(readonly = true)
-    protected File anchorSourceDirectory;
-
-    /**
-     * Update dockerfile
+     * Controls whether a Dockerfile is updated with logic to copy and build the Habushu project and its dependencies
+     * within the container. If set to false, the Dockerfile will not be updated.
      */
     @Parameter(defaultValue = "true", property = "habushu.updateDockerfile")
     protected boolean updateDockerfile;
 
     /**
-     * Dockerfile to be updated with the stage content
+     * Dockerfile to be updated with containerization logic. Must be set if `updateDockerfile` is true.
      */
     @Parameter(property = "habushu.dockerfile")
     protected File dockerfile;
 
-    private Path anchorOutputDirectory;
+    /**
+     * The directory that will serve as the context for the Docker build. This directory must contain the `stagingDirectory`.
+     * Defaults to the project's base directory.
+     */
+    @Parameter(defaultValue = "${project.basedir}", property = "habushu.dockerContext")
+    protected File dockerContext;
+
+    /**
+     * The user to set as the owner of the virtual env. This is useful when the Docker build is run as a non-root user.
+     * Set to an empty string to disable.
+     */
+    @Parameter(defaultValue = "1001", property = "habushu.dockerUser")
+    protected String dockerUser;
+
+    /**
+     * The base image to use for the Dockerfile. The base image will be used both to bundle the virtual environment for
+     * the target project and to run the final container, as the venv must be built on the same platform as the final
+     * runtime. The base image must have the correct Python version resolvable via the PATH.
+     */
+    @Parameter(defaultValue = "python:3.11-slim", property = "habushu.dockerBase")
+    protected String dockerBase;
 
     protected final String HABUSHU = "habushu";
-    protected final String GLOB_RECURSIVE_ALL = "/**";
+
     /**
      * Overriding to allow execution in non-habushu projects.
      */
@@ -138,17 +99,11 @@ public class ContainerizeDepsMojo extends AbstractHabushuMojo {
 
     @Override
     protected void doExecute() throws MojoExecutionException, MojoFailureException {
-        if (this.anchorSourceDirectory == null) {
-            this.anchorSourceDirectory = new File(session.getExecutionRootDirectory());
-        }
-
-        if (this.workingDirectoryRelativeToBasedir == null) {
-            this.workingDirectoryRelativeToBasedir = "";
-        }
+        Path sourceRoot = Path.of(session.getExecutionRootDirectory());
 
         ProjectCollectionResult result = getHabushuProjects();
         try {
-            Path targetProjectPath = copySourceCode(result);
+            Path targetProjectPath = stageHabushuProjects(sourceRoot, result);
             if (this.updateDockerfile) {
                 if (this.dockerfile == null) {
                     throw new HabushuException("`updateDockerfile` is set to true but `dockerfile` is not specified");
@@ -156,80 +111,76 @@ public class ContainerizeDepsMojo extends AbstractHabushuMojo {
                 performDockerfileUpdateForVirtualEnvironment(targetProjectPath);
             }
         } catch (IOException e) {
-            throw new HabushuException(e);
+            throw new HabushuException("Failed to prepare containerization of Habushu dependency", e);
         }
     }
 
     /**
      * Copies the relevant source files by leveraging {@link FileSet}s to filter appropriately.
+     *
+     * @param sourceRoot the root directory that contains the source files of the projects
      * @param projectCollection corresponding projects of the pom's habushu-type dependencies
      * @return the relative path from the staging root to the primary project being containerized
-     * @throws IOException
-     * @throws MojoExecutionException
+     * @throws IOException if an error occurs while copying files
      */
-    protected Path copySourceCode(ProjectCollectionResult projectCollection) throws IOException, MojoExecutionException {
-        this.anchorOutputDirectory = Path.of(containerizeSupportDirectory, this.anchorSourceDirectory.getName());
-        Path srcRoot = this.anchorSourceDirectory.toPath();
+    protected Path stageHabushuProjects(Path sourceRoot, ProjectCollectionResult projectCollection) throws IOException {
+        Path destRoot = getStagingPath();
         Path primaryProjectPath = null;
 
-        Map<Path, FileSet> dependencyFileSets = new HashMap<>();
         for (MavenProject project : projectCollection.getAllProjects()) {
-            Path projectPath = getWorkingDirectoryPath(project);
-            Path relativeProjectPath = srcRoot.relativize(projectPath);
-            FileSet fileSet = getDefaultFileSet(project);
-            fileSet.setDirectory(projectPath.toString());
-            dependencyFileSets.put(relativeProjectPath, fileSet);
+            Path projectPath = project.getBasedir().toPath();
+            Path relativeProjectPath = sourceRoot.relativize(projectPath);
             if (project.equals(projectCollection.getPrimaryProject())) {
                 primaryProjectPath = relativeProjectPath;
             }
+
+            FileSet sourceFileSet = getSourceSet();
+            sourceFileSet.setDirectory(projectPath.toString());
+            stageSourcesForProject(sourceRoot, destRoot, sourceFileSet, relativeProjectPath);
         }
         if( primaryProjectPath == null ) {
-            throw new HabushuException("Primary project was not included in the set of projects. Ensure the habushu project is in the build and the pom dependencies are configured correctly");
-        }
-
-        FileSetManager fileSetManager = new FileSetManager();
-        for (Path project : dependencyFileSets.keySet()) {
-            FileSet fileSet = dependencyFileSets.get(project);
-            logger.info("Staging {} monorepo dependency files from {}.",
-                    fileSetManager.getIncludedFiles(fileSet).length,
-                    project.getFileName()
-            );
-            for (String includedFile : fileSetManager.getIncludedFiles(fileSet)) {
-                Path relativePath = project.resolve(includedFile);
-                Files.createDirectories(this.anchorOutputDirectory.resolve(relativePath).getParent());
-                Files.copy(srcRoot.resolve(relativePath), this.anchorOutputDirectory.resolve(relativePath), StandardCopyOption.REPLACE_EXISTING);
-            }
+            throw new HabushuException("Primary project was not included in the set of projects. Ensure the Habushu project is in the build and the POM dependencies are configured correctly.");
         }
         return primaryProjectPath;
     }
 
-    private Path getWorkingDirectoryPath(MavenProject project) {
-        return project.getBasedir().toPath().resolve(workingDirectoryRelativeToBasedir);
+    /**
+     * Moves the files identified by the given {@link FileSet} from the source root to the destination root, preserving
+     * the relative path of the project.
+     *
+     * @param sourceRoot the root directory that contains the project
+     * @param destRoot the root directory to copy sources into
+     * @param sourceFileSet the set of files to copy
+     * @param relativeProjectPath the relative path of the project from the source/destination root
+     * @throws IOException
+     */
+    protected void stageSourcesForProject(Path sourceRoot, Path destRoot, FileSet sourceFileSet, Path relativeProjectPath) throws IOException {
+        FileSetManager fileSetManager = new FileSetManager();
+        logger.info("Staging {} monorepo dependency files from {}.",
+                fileSetManager.getIncludedFiles(sourceFileSet).length,
+                relativeProjectPath.getFileName()
+        );
+        for (String includedFile : fileSetManager.getIncludedFiles(sourceFileSet)) {
+            Path relativeFilePath = relativeProjectPath.resolve(includedFile);
+            Files.createDirectories(destRoot.resolve(relativeFilePath).getParent());
+            Files.copy(sourceRoot.resolve(relativeFilePath), destRoot.resolve(relativeFilePath));
+        }
     }
 
-    private FileSet getDefaultFileSet(MavenProject project) throws MojoExecutionException {
-        FileSet fileSet = new FileSet();
-        fileSet.addExclude(distDirectoryRelativeToBasedir + GLOB_RECURSIVE_ALL);
-        fileSet.addExclude(targetDirectoryRelativeToBasedir + GLOB_RECURSIVE_ALL);
-
-        // find the virtual environment path for the given Habushu-packaged project
-        String virtualEnvironmentPath = HabushuUtil.findCurrentVirtualEnvironmentFullPath(
-                pythonVersion,
-                usePyenv,
-                new File(project.getBuild().getDirectory() + patchInstallScriptRelativeToBuildDirectory),
-                new File(project.getBasedir() + workingDirectoryRelativeToBasedir),
-                rewriteLocalPathDepsInArchives,
-                getLog()
-        );
-        virtualEnvironmentPath = HabushuUtil.getCleanVirtualEnvironmentPath(virtualEnvironmentPath);
-
-        // if a valid virtual environment was found, relativize and add to the fileSet for exclusions
-        if (virtualEnvironmentPath != null && !virtualEnvironmentPath.isEmpty()
-                && new File(virtualEnvironmentPath).isDirectory()) {
-            Path venvDirRelativeToBasedir = getWorkingDirectoryPath(project)
-                    .relativize(Paths.get(virtualEnvironmentPath));
-            fileSet.addExclude(venvDirRelativeToBasedir + GLOB_RECURSIVE_ALL);
+    protected FileSet getSourceSet() {
+        if( defaultSourceSet != null ) {
+            return defaultSourceSet;
         }
+
+        FileSet fileSet = new FileSet();
+        Path srcPath = sourceDirectory.toPath();
+        Path basePath = project.getBasedir().toPath();
+        Path relativeSrc = basePath.relativize(srcPath);
+        fileSet.addInclude(relativeSrc +"/**");
+        fileSet.addInclude("pyproject.toml");
+        fileSet.addInclude("poetry.toml");
+        fileSet.addInclude("poetry.lock");
+        fileSet.addInclude("README.md");
 
         return fileSet;
     }
@@ -243,8 +194,6 @@ public class ContainerizeDepsMojo extends AbstractHabushuMojo {
         Set<Dependency> directHabushuDeps = session.getCurrentProject().getDependencies().stream()
                 .filter(d -> HABUSHU.equals(d.getType()))
                 .collect(Collectors.toSet());
-        // TODO: modify this exception throw, once support for
-        //  more than one direct monorepo dep specification is implemented
         if (directHabushuDeps.size() > 1) {
             throw new HabushuException("More than one `habushu` packaged dependency was found."
                     + "Only one habushu-type dependency should be specified.");
@@ -288,12 +237,8 @@ public class ContainerizeDepsMojo extends AbstractHabushuMojo {
         return this.session;
     }
 
-    protected void setAnchorSourceDirectory(File anchorSourceDirectory) {
-        this.anchorSourceDirectory = anchorSourceDirectory;
-    }
-
-    public Path getAnchorOutputDirectory() {
-        return anchorOutputDirectory;
+    protected Path getStagingPath() {
+        return stagingDirectory.toPath();
     }
 
     protected void setDockerfile(File dockerfile) {
@@ -305,10 +250,10 @@ public class ContainerizeDepsMojo extends AbstractHabushuMojo {
     }
 
     protected void performDockerfileUpdateForVirtualEnvironment(Path targetProjectPath) {
-        Path outputDir = session.getCurrentProject().getBasedir().toPath().relativize(this.anchorOutputDirectory);
+        Path outputDir = dockerContext.toPath().relativize(getStagingPath());
         String updatedDockerfile =
                 ContainerizeDepsDockerfileHelper.updateDockerfileWithContainerStageLogic(
-                        this.dockerfile, outputDir.toString(), targetProjectPath.toString());
+                        this.dockerfile, outputDir.toString(), targetProjectPath.toString(), dockerUser, dockerBase);
 
         try (Writer writer = new FileWriter(this.dockerfile)) {
             writer.write(updatedDockerfile);
@@ -319,24 +264,27 @@ public class ContainerizeDepsMojo extends AbstractHabushuMojo {
     }
 
     /**
-      * Result object for collecting Maven projects that are required to containerize a given Habushu project.  There is
-      * one "primary" project that is the direct target of containerization.  Other Habushu projects are included when
-      * they are monorepo dependencies of the primary project.
-      */
+     * Result object for collecting Maven projects that are required to containerize a given Habushu project.  There is
+     * one "primary" project that is the direct target of containerization.  Other Habushu projects are included when
+     * they are monorepo dependencies of the primary project.
+     */
     protected static class ProjectCollectionResult {
         private final Dependency directDependency;
         private final Set<MavenProject> habushuProjects; //includes primaryProject
         private MavenProject primaryProject;
+
         public ProjectCollectionResult(Dependency directDependency) {
             this.directDependency = directDependency;
             this.habushuProjects = new HashSet<>();
         }
+
         public void addProject(MavenProject project) {
             this.habushuProjects.add(project);
             if (toGav(directDependency).equals(toGav(project))) {
                 primaryProject = project;
             }
         }
+
         /**
          * @return all projects including the primary project
          */
@@ -347,5 +295,4 @@ public class ContainerizeDepsMojo extends AbstractHabushuMojo {
             return primaryProject;
         }
     }
-
 }

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/util/ContainerizeDepsDockerfileHelper.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/util/ContainerizeDepsDockerfileHelper.java
@@ -1,5 +1,6 @@
 package org.technologybrewery.habushu.util;
 
+import org.apache.commons.lang3.StringUtils;
 import org.technologybrewery.habushu.HabushuException;
 
 import java.io.BufferedReader;
@@ -15,6 +16,8 @@ public class ContainerizeDepsDockerfileHelper {
     public static final String HABUSHU_COMMENT_START = " - HABUSHU GENERATED CODE (DO NOT MODIFY)";
     public static final String HABUSHU_COMMENT_END = " - HABUSHU GENERATED CODE (END)";
     public static final String REPLACE_WITH_SINGLE_REPO_PROJECT_DIR = "REPLACE_WITH_SINGLE_REPO_PROJECT_DIR";
+    public static final String CHOWN = "CHOWN_PLACEHOLDER";
+    public static final String BASE_IMAGE = "BASE_IMAGE";
     public static final String ANCHOR_DIRECTORY = "ANCHOR_DIRECTORY";
     public static final String FINAL_STAGE_TEMPLATE = "dockerfile_final_stage_template";
     public static final String BUILDER_STAGE_TEMPLATE = "dockerfile_builder_stage_template";
@@ -26,7 +29,7 @@ public class ContainerizeDepsDockerfileHelper {
      * @param moduleBaseDir the module base directory
      * @return container stage content
      */
-    public static String createContainerStageContentFrom(String template, String anchorDirectory, String moduleBaseDir) {
+    public static String createContainerStageContentFrom(String template, String anchorDirectory, String moduleBaseDir, String owner, String baseImage) {
         StringBuilder content = new StringBuilder();
         InputStream inputStream = ContainerizeDepsDockerfileHelper.class.getClassLoader().getResourceAsStream(template);
 
@@ -34,12 +37,22 @@ public class ContainerizeDepsDockerfileHelper {
             String line = buffer.readLine();
 
             while (line != null) {
-                line = line.strip();
+                line = line.stripTrailing();
                 if (line.contains(ANCHOR_DIRECTORY)) {
                     line = line.replaceAll(ANCHOR_DIRECTORY, anchorDirectory);
                 }
                 if (line.contains(REPLACE_WITH_SINGLE_REPO_PROJECT_DIR)) {
                     line = line.replaceAll(REPLACE_WITH_SINGLE_REPO_PROJECT_DIR, moduleBaseDir);
+                }
+                if (line.contains(CHOWN)) {
+                    if (StringUtils.isNotBlank(owner)) {
+                        line = line.replaceAll(CHOWN, "--chown=" + owner);
+                    } else {
+                        line = line.replaceAll(CHOWN, "");
+                    }
+                }
+                if (line.contains(BASE_IMAGE)) {
+                    line = line.replaceAll(BASE_IMAGE, baseImage);
                 }
                 content.append(line).append("\n");
                 line = buffer.readLine();
@@ -58,19 +71,23 @@ public class ContainerizeDepsDockerfileHelper {
      * @param moduleBaseDir the module base directory
      * @return updated Dockerfile content
      */
-    public static String updateDockerfileWithContainerStageLogic(File dockerFile, String anchorDirectory, String moduleBaseDir) {
-        String builderStageContent = ContainerizeDepsDockerfileHelper.createContainerStageContentFrom(BUILDER_STAGE_TEMPLATE, anchorDirectory, moduleBaseDir);
-        String finalStageContent = ContainerizeDepsDockerfileHelper.createContainerStageContentFrom(FINAL_STAGE_TEMPLATE, null, null);
+    public static String updateDockerfileWithContainerStageLogic(File dockerFile, String anchorDirectory, String moduleBaseDir, String owner, String baseImage) {
+        String builderStageContent = ContainerizeDepsDockerfileHelper.createContainerStageContentFrom(BUILDER_STAGE_TEMPLATE, anchorDirectory, moduleBaseDir, owner, baseImage);
+        String finalStageContent = ContainerizeDepsDockerfileHelper.createContainerStageContentFrom(FINAL_STAGE_TEMPLATE, null, null, owner, baseImage);
         StringBuilder content = new StringBuilder();
-        Boolean builderStageContentIncluded = false;
-        Boolean finalStageContentIncluded = false;
+        boolean builderStageContentIncluded = false;
+        boolean finalStageContentIncluded = false;
+        int firstFromLine = -1;
 
         boolean skipLine = false;
         try (BufferedReader buffer = new BufferedReader(new FileReader(dockerFile))) {
             String line = buffer.readLine();
 
             while (line != null) {
-                line = line.strip();
+                line = line.stripTrailing();
+                if(firstFromLine < 0 && line.strip().startsWith("FROM")) {
+                    firstFromLine = content.length();
+                }
 
                 // start skipping the line if reads HABUSHU_COMMENT_START
                 if (!skipLine && line.contains(HABUSHU_COMMENT_START)) {
@@ -97,7 +114,7 @@ public class ContainerizeDepsDockerfileHelper {
                 line = buffer.readLine();
             }
             if (!builderStageContentIncluded) {
-                content.insert(0, wrapWithHabushuComment(builderStageContent, HABUSHU_BUILDER_STAGE) + "\n\n");
+                content.insert(Integer.max(firstFromLine, 0), wrapWithHabushuComment(builderStageContent, HABUSHU_BUILDER_STAGE) + "\n\n");
             }
             if (!finalStageContentIncluded) {
                 content.append("\n");

--- a/habushu-maven-plugin/src/main/resources/dockerfile_builder_stage_template
+++ b/habushu-maven-plugin/src/main/resources/dockerfile_builder_stage_template
@@ -1,20 +1,19 @@
-FROM registry.access.redhat.com/ubi9/python-311:1-66 as habushu_builder
+FROM BASE_IMAGE AS habushu_builder
 # Poetry and supporting plugin installations
-RUN pip install poetry && \
+RUN python -m ensurepip --upgrade && \
+    pip install poetry && \
     poetry self add poetry-monorepo-dependency-plugin && \
     poetry self add poetry-plugin-bundle
 
 WORKDIR /work-dir
-COPY --chown=1001 ANCHOR_DIRECTORY ./containerize-support/
+COPY CHOWN_PLACEHOLDER ANCHOR_DIRECTORY ./containerize-support/
 RUN find . -type f -name pyproject.toml -exec sed -i 's|develop[[:blank:]]*=[[:blank:]]*true|develop = false|g' {} \;
 
 USER root
 WORKDIR /work-dir/containerize-support/REPLACE_WITH_SINGLE_REPO_PROJECT_DIR
-# ensure Poetry's cache directory is propertly set
 ENV POETRY_CACHE_DIR="/.cache/pypoetry"
-# instruct Docker to persistently store the container's Poetry cache while
-# resolving dependencies during the lock process of the venv-specifier and
-# building/exporting the virtual environment of the venv-specifier to /venv
+
+# export target project's virtual environment to /opt/venv
 RUN --mount=type=cache,target=/.cache/pypoetry/ \
     poetry lock && \
-    poetry bundle venv /venv
+    poetry bundle venv /opt/venv

--- a/habushu-maven-plugin/src/main/resources/dockerfile_final_stage_template
+++ b/habushu-maven-plugin/src/main/resources/dockerfile_final_stage_template
@@ -1,6 +1,4 @@
-# copy the pre-built venv from the builder and
-COPY --from=habushu_builder /venv /opt/venv
-# configure the container to use the venv
+FROM BASE_IMAGE AS final
+# Copy venv from builder and activate by adding to the path
+COPY --from=habushu_builder CHOWN_PLACEHOLDER /opt/venv /opt/venv/
 ENV PATH="/opt/venv/bin:$PATH"
-# update the venv python symlink to point to the default python executable
-RUN ln -sf $(which python) /opt/venv/bin/python

--- a/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/ContainerizeDepsSteps.java
+++ b/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/ContainerizeDepsSteps.java
@@ -5,6 +5,7 @@ import io.cucumber.java.Before;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import org.apache.commons.io.FileUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.junit.jupiter.api.Assertions;
@@ -45,6 +46,9 @@ public class ContainerizeDepsSteps {
     public void tearDownMavenPluginTestHarness() throws Exception {
         mojoTestCase.clearMavenProjectFiles();
         mojoTestCase.tearDownPluginTestHarness();
+        if (mojo != null && Files.exists(mojo.getStagingPath())) {
+            FileUtils.deleteDirectory(mojo.getStagingPath().toFile());
+        }
     }
 
     @Given("a single dependency with packaging type habushu")
@@ -58,7 +62,6 @@ public class ContainerizeDepsSteps {
         mojo = (ContainerizeDepsMojo) mojoTestCase.lookupConfiguredMojo(
                 new File(mavenProjectPath, POM_FILE), "containerize-dependencies"
         );
-        mojo.setAnchorSourceDirectory(new File("target/test-classes/containerize-dependencies/default-single-monorepo-dep/test-monorepo").getAbsoluteFile());
         mojo.session.getRequest().setBaseDirectory(new File(targetDefaultSingleMonorepoDepPath));
 
     }
@@ -71,7 +74,7 @@ public class ContainerizeDepsSteps {
     @Then("the source files of the dependency and transitive Habushu-type dependencies are staged for containerization")
     public void
     the_source_files_of_the_dependency_and_transitive_habushu_type_dependencies_are_staged_for_containerization() {
-        assertStaged(mojo.getAnchorOutputDirectory());
+        assertStaged(mojo.getStagingPath());
     }
 
     @Given("no Habushu-type dependencies")
@@ -92,13 +95,12 @@ public class ContainerizeDepsSteps {
 
     @Given("a dockerfile to update")
     public void a_dockerfile_to_update() {
-        dockerfile = new File(mavenProjectPath + "/src/main/resources/docker/Dockerfile");
-        mojo.setDockerfile(dockerfile);
+        setDockerfile("/src/main/resources/docker/Dockerfile");
     }
 
     @Then("all the source files to build the dependency are staged in the build directory")
     public void all_the_source_files_to_build_the_dep_are_staged_in_the_build_directory() {
-        assertStaged(mojo.getAnchorOutputDirectory());
+        assertStaged(mojo.getStagingPath());
     }
 
     @Then("the Dockerfile is updated to leverage a virtual environment for the dependency")
@@ -117,19 +119,22 @@ public class ContainerizeDepsSteps {
 
     @Given("a dockerfile already updated")
     public void a_dockerfile_already_updated() {
-        dockerfile = new File(mavenProjectPath + "/src/main/resources/docker/UpdatedDockerfile");
-        mojo.setDockerfile(dockerfile);
+        setDockerfile("/src/main/resources/docker/UpdatedDockerfile");
     }
 
     @Given("a dockerfile without any habushu builder or final stage comment tag")
     public void a_dockerfile_without_comment_tag() {
-        dockerfile = new File(mavenProjectPath + "/src/main/resources/docker/NoHabushuCommentDockerfile");
-        mojo.setDockerfile(dockerfile);
+        setDockerfile("/src/main/resources/docker/NoHabushuCommentDockerfile");
     }
 
     @Given("updateDockerfile set false")
     public void updateDockerfile_to_false() {
         mojo.setUpdateDockerfile(false);
+    }
+
+    private void setDockerfile(String dockerPath) {
+        dockerfile = new File(mavenProjectPath + dockerPath);
+        mojo.setDockerfile(dockerfile);
     }
 
     private boolean isNonExistentOrEmptyDir(File dir) {
@@ -158,9 +163,11 @@ public class ContainerizeDepsSteps {
 
         assertFile(actualFiles, "extensions/extensions-python-dep-X/src/python_dep_x/python_dep_x.py");
         assertFile(actualFiles, "extensions/extensions-python-dep-X/pyproject.toml");
+        assertFile(actualFiles, "extensions/extensions-python-dep-X/poetry.toml");
         assertFile(actualFiles, "extensions/extensions-python-dep-X/README.md");
         assertFile(actualFiles, "foundation/foundation-python-dep-Y/src/python_dep_y/python_dep_y.py");
         assertFile(actualFiles, "foundation/foundation-python-dep-Y/pyproject.toml");
+        assertFile(actualFiles, "foundation/foundation-python-dep-Y/poetry.toml");
         assertFile(actualFiles, "foundation/foundation-python-dep-Y/README.md");
     }
 

--- a/habushu-maven-plugin/src/test/resources/containerize-dependencies/default-single-monorepo-dep/test-monorepo/extensions/extensions-monorepo-dep-consuming-application/pom.xml
+++ b/habushu-maven-plugin/src/test/resources/containerize-dependencies/default-single-monorepo-dep/test-monorepo/extensions/extensions-monorepo-dep-consuming-application/pom.xml
@@ -17,9 +17,6 @@
                 <groupId>org.technologybrewery.habushu</groupId>
                 <artifactId>habushu-maven-plugin</artifactId>
                 <version>${project.version}</version>
-                <configuration>
-                    <usePyenv>false</usePyenv>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/habushu-maven-plugin/src/test/resources/containerize-dependencies/default-single-monorepo-dep/test-monorepo/extensions/extensions-python-dep-X/poetry.toml
+++ b/habushu-maven-plugin/src/test/resources/containerize-dependencies/default-single-monorepo-dep/test-monorepo/extensions/extensions-python-dep-X/poetry.toml
@@ -1,0 +1,3 @@
+[virtualenvs]
+prefer-active-python = true
+in-project = true

--- a/habushu-maven-plugin/src/test/resources/containerize-dependencies/default-single-monorepo-dep/test-monorepo/foundation/foundation-python-dep-Y/poetry.toml
+++ b/habushu-maven-plugin/src/test/resources/containerize-dependencies/default-single-monorepo-dep/test-monorepo/foundation/foundation-python-dep-Y/poetry.toml
@@ -1,0 +1,3 @@
+[virtualenvs]
+prefer-active-python = true
+in-project = true


### PR DESCRIPTION
Contains the following changes:

- Pull python module source inclusively based on the existing `habushu.sourceDirectory` configuration and remove all of the configs used to configure module source files exclusively
- Move to the `prepare-package` phase, as the docker build itself should occupy the `package` phase
- Add `dockerContext`, `dockerUser` and `dockerBase` configurations for injecting logic into the `Dockerfile`

`dockerBase` (the base image from which to create the builder and final stages) is required to ensure the virtual environment that is created is compatible with the final image. 