### PR TITLE
HAB-188 - Update dockerBuilderBase and dockerFinalbase 

### DIFF
--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/ContainerizeDepsMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/ContainerizeDepsMojo.java
@@ -85,7 +85,7 @@ public class ContainerizeDepsMojo extends AbstractHabushuMojo {
      * compatibility, this image must share a platform with {@link dockerFinalBase}. The base image must have the target
      * Python version resolvable via the PATH.
      */
-    @Parameter(defaultValue = "python:3.11", property = "habushu.dockerBuilderBase")
+    @Parameter(defaultValue = "docker.io/python:3.11", property = "habushu.dockerBuilderBase")
     protected String dockerBuilderBase;
 
     /**
@@ -94,7 +94,7 @@ public class ContainerizeDepsMojo extends AbstractHabushuMojo {
      * this image must share a platform with {@link dockerBuilderBase}. The base image must have the target Python
      * version resolvable via the PATH.
      */
-    @Parameter(defaultValue = "python:3.11-slim", property = "habushu.dockerFinalBase")
+    @Parameter(defaultValue = "docker.io/python:3.11-slim", property = "habushu.dockerFinalBase")
     protected String dockerFinalBase;
 
     protected final String HABUSHU = "habushu";


### PR DESCRIPTION
Update dockerBuilderBase and dockerFinalbase values to include registry so image names are fully qualified:

- docker.io/python:3.11
- docker.io/python:3.11-slim