### PR TITLE
#196 :thread: mark plugins for thread safety

### DIFF
--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/BehaveBddTestMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/BehaveBddTestMojo.java
@@ -26,7 +26,8 @@ import java.util.Map;
  * If {@link #behaveOptions} are provided, {@link #behaveExcludeManualTag} is
  * effectively overridden and ignored.
  */
-@Mojo(name = "behave-bdd-test", defaultPhase = LifecyclePhase.TEST, requiresDependencyResolution = ResolutionScope.TEST)
+@Mojo(name = "behave-bdd-test", defaultPhase = LifecyclePhase.TEST, requiresDependencyResolution = ResolutionScope.TEST,
+        threadSafe = true)
 public class BehaveBddTestMojo extends AbstractHabushuMojo {
 
     protected static final String BEHAVE_PACKAGE = "behave";

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/BuildDeploymentArtifactsMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/BuildDeploymentArtifactsMojo.java
@@ -24,7 +24,7 @@ import java.util.List;
  * {@link #exportRequirementsFile} flag</li>
  * </ul>
  */
-@Mojo(name = "build-deployment-artifacts", defaultPhase = LifecyclePhase.PACKAGE)
+@Mojo(name = "build-deployment-artifacts", defaultPhase = LifecyclePhase.PACKAGE, threadSafe = true)
 public class BuildDeploymentArtifactsMojo extends AbstractHabushuMojo {
 
     /**

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/CleanHabushuMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/CleanHabushuMojo.java
@@ -21,7 +21,7 @@ import java.util.List;
  * virtual environment that is created/managed by Poetry if the
  * {@link #deleteVirtualEnv} option is enabled.
  */
-@Mojo(name = "clean-habushu", defaultPhase = LifecyclePhase.CLEAN)
+@Mojo(name = "clean-habushu", defaultPhase = LifecyclePhase.CLEAN, threadSafe = true)
 public class CleanHabushuMojo extends CleanMojo {
 
     /**

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/ContainerizeDepsMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/ContainerizeDepsMojo.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
  * to the target directory along with the source files of
  * any transitive path-based dependencies.
  */
-@Mojo(name = "containerize-dependencies", defaultPhase = LifecyclePhase.PREPARE_PACKAGE)
+@Mojo(name = "containerize-dependencies", defaultPhase = LifecyclePhase.PREPARE_PACKAGE, threadSafe = true)
 public class ContainerizeDepsMojo extends AbstractHabushuMojo {
 
     private static final Logger logger = LoggerFactory.getLogger(ContainerizeDepsMojo.class);

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/FormatPythonMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/FormatPythonMojo.java
@@ -14,7 +14,8 @@ import org.technologybrewery.habushu.exec.PoetryCommandHelper;
  * Leverages the black formatter package to format both source and test Python
  * directories using Poetry's run command.
  */
-@Mojo(name = "format-python", defaultPhase = LifecyclePhase.PROCESS_CLASSES, requiresDependencyResolution = ResolutionScope.COMPILE)
+@Mojo(name = "format-python", defaultPhase = LifecyclePhase.PROCESS_CLASSES,
+		requiresDependencyResolution = ResolutionScope.COMPILE, threadSafe = true)
 public class FormatPythonMojo extends AbstractHabushuMojo {
 
     protected static final String BLACK_PACKAGE = "black";

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/InitializeHabushuMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/InitializeHabushuMojo.java
@@ -15,7 +15,7 @@ import org.technologybrewery.habushu.exec.PoetryCommandHelper;
  * in the {@code pom.xml} with the version in the project's
  * {@code pyproject.toml}.
  */
-@Mojo(name = "initialize-habushu", defaultPhase = LifecyclePhase.INITIALIZE)
+@Mojo(name = "initialize-habushu", defaultPhase = LifecyclePhase.INITIALIZE, threadSafe = true)
 public class InitializeHabushuMojo extends AbstractHabushuMojo {
 
     @Override

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/InstallDependenciesMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/InstallDependenciesMojo.java
@@ -46,7 +46,7 @@ import java.util.concurrent.TimeUnit;
  * the module's pyproject.toml configuration as a supplemental source of
  * dependencies, if it is not already configured in the pyproject.toml
  */
-@Mojo(name = "install-dependencies", defaultPhase = LifecyclePhase.COMPILE)
+@Mojo(name = "install-dependencies", defaultPhase = LifecyclePhase.COMPILE, threadSafe = true)
 public class InstallDependenciesMojo extends AbstractHabushuMojo {
 
     private static final String EQUALS = "=";

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/PublishToPyPiRepoMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/PublishToPyPiRepoMojo.java
@@ -53,7 +53,7 @@ import org.technologybrewery.habushu.exec.PoetryCommandHelper;
  * {@link #snapshotNumberDateFormatPattern} to adjust the formatting of the
  * numeric component of the published version.
  */
-@Mojo(name = "publish-to-pypi-repo", defaultPhase = LifecyclePhase.DEPLOY)
+@Mojo(name = "publish-to-pypi-repo", defaultPhase = LifecyclePhase.DEPLOY, threadSafe = true)
 public class PublishToPyPiRepoMojo extends AbstractHabushuMojo {
 
     private static final String VERSION = "version";

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/RunCommandInVirtualEnvMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/RunCommandInVirtualEnvMojo.java
@@ -18,7 +18,7 @@ import org.technologybrewery.habushu.exec.PoetryCommandHelper;
  * gRPC/protobuf bindings as an automated part of the build following dependency
  * installation.
  */
-@Mojo(name = "run-command-in-virtual-env")
+@Mojo(name = "run-command-in-virtual-env", threadSafe = true)
 public class RunCommandInVirtualEnvMojo extends AbstractHabushuMojo {
 
     /**

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/ValidatePyenvAndPoetryMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/ValidatePyenvAndPoetryMojo.java
@@ -21,7 +21,7 @@ import org.codehaus.plexus.util.StringUtils;
  * {@code poetry-monorepo-dependency-plugin})</li>
  * </ul>
  */
-@Mojo(name = "validate-pyenv-and-poetry", defaultPhase = LifecyclePhase.VALIDATE)
+@Mojo(name = "validate-pyenv-and-poetry", defaultPhase = LifecyclePhase.VALIDATE, threadSafe = true)
 public class ValidatePyenvAndPoetryMojo extends AbstractHabushuMojo {
 
     /**

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/ValidatePythonSourceMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/ValidatePythonSourceMojo.java
@@ -10,7 +10,8 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
  * Leverages the lint package to validate both source and test Python
  * directories using Poetry's run command.
  */
-@Mojo(name = "validate-python-source", defaultPhase = LifecyclePhase.PROCESS_CLASSES, requiresDependencyResolution = ResolutionScope.COMPILE)
+@Mojo(name = "validate-python-source", defaultPhase = LifecyclePhase.PROCESS_CLASSES,
+        requiresDependencyResolution = ResolutionScope.COMPILE, threadSafe = true)
 public class ValidatePythonSourceMojo extends AbstractValidateMojo {
 
     /**

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/ValidatePythonTestMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/ValidatePythonTestMojo.java
@@ -8,7 +8,8 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import java.util.List;
 
-@Mojo(name = "validate-python-test", defaultPhase = LifecyclePhase.PROCESS_TEST_CLASSES, requiresDependencyResolution = ResolutionScope.COMPILE)
+@Mojo(name = "validate-python-test", defaultPhase = LifecyclePhase.PROCESS_TEST_CLASSES,
+        requiresDependencyResolution = ResolutionScope.COMPILE, threadSafe = true)
 public class ValidatePythonTestMojo extends AbstractValidateMojo {
 
     /**


### PR DESCRIPTION
I did look at these to ensure they are thread-safe.  It just so happens (as you would expect for most Maven plugins), they were all good to go and just needed to be annotated to formally denote their support.