### PR TITLE
[#203] Create Baton migrations for Poetry v2.0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1014,3 +1014,15 @@ If you are working on Habushu, please be aware of some nuances in working with a
 * `mvn clean install -Pbootstrap`: Builds the `habushu-maven-plugin` such that the custom `habushu` lifecycle may be utilized within subsequent builds.
 * **NOTE:** If updates are made to the `habushu` lifecycle (i.e. updates to the `habushu` lifecycle mapping configuration made in `habushu-maven-plugin/src/main/resources/META-INF/plexus/components.xml`), developers **MUST**  changes require two builds to test - one to build the lifecycle, then a second to use that updated lifecycle.  Code changes to `Mojo` classes within the existing `habushu` lifecycle work via normal builds without the need for a second pass.
 * `mvn clean install -Pdefault`: (ACTIVE BY DEFAULT - `-Pdefault` does not need to be specified) builds all modules.  Developers may use this profile to build and apply changes to existing `habushu-maven-plugin` `Mojo` classes
+
+## Poetry v2.0.0+ Changes ##
+When on Poetry v2.0.0 and later, Baton migrations will automatically run on all `pyproject.toml` files in your Habushu project.
+This update introduces three migrations that ensure configurations are more in line with [PEP 621](https://peps.python.org/pep-0621/). 
+- `PoetryToProjectMigration`: Adds `[project]` section into TOML file and moves relevant fields from `[tool.poetry]` to `[project]`
+- `PoetryToProjectRequiresPythonMigration`: Relocates the Python dependency from `[tool.poetry.dependencies]` to the `requires-python` entry under `[project]`
+- `PoetryToProjectDynamicMigration`: Introduces a `dynamic` field under `[project]` that automatically includes `version` and `dependency`, if not already present. If a single `readme` (as a string) is included in `[tool.poetry]`, then migrates it from `[tool.poetry]` to `[project]`. If multiple `readme` values are defined (as a table) in `[tool.poetry]`, `readme` is added to the `dynamic` field list.
+
+**Note:** Baton migrations are forward compatible only. If you upgrade to Poetry v2.0+ and later decide to downgrade, you will need to manually revert the changes in your TOML files.
+
+
+

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/migration/poetryv2migrations/AbstractPoetryMigration.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/migration/poetryv2migrations/AbstractPoetryMigration.java
@@ -1,0 +1,119 @@
+package org.technologybrewery.habushu.migration.poetryv2migrations;
+
+import org.apache.maven.project.MavenProject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.technologybrewery.baton.AbstractMigration;
+import org.technologybrewery.habushu.exec.PoetryCommandHelper;
+import org.technologybrewery.habushu.util.TomlReplacementTuple;
+import org.technologybrewery.habushu.util.TomlUtils;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Provides common logic to migrate TOML file entries for Poetry versions 2.0.0 or later.
+ * Updates configurations to better comply with PEP 621 standards (https://peps.python.org/pep-0621/).
+ */
+public abstract class AbstractPoetryMigration extends AbstractMigration {
+    private static final Logger logger = LoggerFactory.getLogger(AbstractPoetryMigration.class);
+    protected File workingDirectory;
+    protected boolean isPoetryVersionAtLeast2 = checkPoetryVersionAtLeast2();
+
+    @Override
+    public void setMavenProject(MavenProject project) {
+        super.setMavenProject(project);
+        this.workingDirectory = project.getBasedir();
+    }
+
+    protected boolean checkPoetryVersionAtLeast2(){
+        PoetryCommandHelper poetryHelper = new PoetryCommandHelper(workingDirectory);
+        return poetryHelper.isPoetryVersionAtLeast2();
+    }
+
+    public void setWorkingDirectory(File workingDirectory){
+        this.workingDirectory = workingDirectory;
+    }
+
+    public void setIsPoetryVersionAtLeast2(boolean isPoetryVersionAtLeast2){
+        this.isPoetryVersionAtLeast2 = isPoetryVersionAtLeast2;
+    }
+
+    /**
+     * Converts a List of Strings containing authors/maintainer data into a toml-formatted string.
+     */
+    protected String convertListOfStringsToString(List<String> listOfStrings) {
+        StringBuilder sb = new StringBuilder();
+        int valuesRemaining = listOfStrings.size();
+        sb.append("[");
+
+        for (String listValue : listOfStrings) {
+            int start = listValue.indexOf("<");
+            int end = listValue.indexOf(">");
+
+            if (start != -1 && end != -1 && end > start) {
+                sb.append("{");
+                sb.append(buildNameString(listValue.substring(0, start).strip()));
+                sb.append(", ");
+                sb.append(buildEmailString(listValue.substring(start + 1, end).strip()));
+                sb.append("}");
+            } else  {
+                logger.warn("Field not in expected \"name <email>\" format!");
+                if (!listValue.contains("@")){
+                    logger.warn("Attempting to parse {} as name string", listValue);
+                    sb.append("{").append(buildNameString(listValue)).append("}");
+                } else {
+                    logger.warn("Attempting to parse {} as e-mail string", listValue);
+                    sb.append("{").append(buildEmailString(listValue)).append("}");
+                }
+            }
+            valuesRemaining--;
+            if (valuesRemaining > 0) {
+                sb.append(", ");
+            }
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+
+    protected String buildNameString(String name){
+        return "name = " + TomlUtils.DOUBLE_QUOTE + name + TomlUtils.DOUBLE_QUOTE;
+    }
+
+    protected String buildEmailString(String email){
+        return "email = " + TomlUtils.DOUBLE_QUOTE + email + TomlUtils.DOUBLE_QUOTE;
+    }
+
+
+    /**
+     * Appends dependency definitions to the given file content if their keys are not already present in [project] group
+     */
+    protected StringBuilder injectDependencies(StringBuilder fileContent, List<String> existingProjectKeys, Map<String, TomlReplacementTuple> replacements) {
+        StringBuilder sb = new StringBuilder();
+        for (Map.Entry<String, TomlReplacementTuple> entry : replacements.entrySet()) {
+            // Only inject if the key is not already in the [project] section.
+            if (!existingProjectKeys.contains(entry.getKey())) {
+                sb.append(entry.getKey())
+                        .append(" = ")
+                        .append(TomlUtils.escapeTomlRightHandSide(entry.getValue().getOriginalOperatorAndVersion()))
+                        .append("\n");
+            } else {
+                logger.warn("Skipping migration for duplicate entry: {}", entry.getKey());
+            }
+        }
+        return fileContent.append(sb);
+    }
+
+    /**
+     * Wraps each string in given list with double quotes and then join them with a comma and a space
+     */
+    protected String joinQuoted(List<String> list) {
+        return list.stream()
+                .map(item -> TomlUtils.DOUBLE_QUOTE + item + TomlUtils.DOUBLE_QUOTE)
+                .collect(Collectors.joining(", "));
+    }
+
+}

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryToProjectDynamicMigration.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryToProjectDynamicMigration.java
@@ -1,0 +1,187 @@
+package org.technologybrewery.habushu.migration.poetryv2migrations;
+
+import com.electronwill.nightconfig.core.Config;
+import com.electronwill.nightconfig.core.file.FileConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.technologybrewery.habushu.util.TomlUtils;
+import org.technologybrewery.baton.BatonException;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Provides functionality to add/update the dynamic field in the [project] section of a TOML file and migrate readme fields, if present.
+ * Adds any entries listed in dynamicEntriesExpected to [project.dynamic], unless already present.
+ * If a single readme value (as a string) is specified under [tool.poetry], it is migrated from [tool.poetry] to [project.readme].
+ * If multiple readmes are specified, the readme entry is added into [project.dynamic].
+ * Runs when on Poetry v2.0.0 or later.
+ */
+public class PoetryToProjectDynamicMigration extends AbstractPoetryMigration{
+    private static final Logger logger = LoggerFactory.getLogger(PoetryToProjectDynamicMigration.class);
+    private final List<String> dynamicEntriesExpected = new ArrayList<>(Arrays.asList(TomlUtils.VERSION, TomlUtils.DEPENDENCIES));
+    private final List<String> dynamicEntriesToAdd = new ArrayList<>();
+    private final List<String> dynamicEntriesActual = new ArrayList<>();
+    private boolean addDynamicEntryToProject;
+    private boolean appendEntriesToDynamic;
+    private boolean addReadMeEntryToProject;
+    private String readMeAsString;
+
+    @Override
+    protected boolean shouldExecuteOnFile(File file) {
+        boolean shouldExecute = false;
+
+        if (!isPoetryVersionAtLeast2) {
+            return false;
+        }
+
+        try (FileConfig tomlFileConfig = FileConfig.of(file)) {
+            tomlFileConfig.load();
+
+            // check if [tool.poetry] has a readme field
+            Optional<Config> toolPoetryOpt = tomlFileConfig.getOptional(TomlUtils.TOOL_POETRY);
+            if(toolPoetryOpt.isPresent()){
+                Config toolPoetryGroup = toolPoetryOpt.get();
+                if (toolPoetryGroup.contains(TomlUtils.README)){
+                    Object readMeEntry = toolPoetryGroup.get(TomlUtils.README);
+                    // if [tool.poetry.readme] contains a table, then append "readme" to the expected list of dynamic entries
+                    if (readMeEntry instanceof List<?>){
+                        dynamicEntriesExpected.add(TomlUtils.README);
+                    } else {
+                        // if [tool.poetry.readme] contains a string, then migrate "readme" entry to [project]
+                        addReadMeEntryToProject = true;
+                        readMeAsString = (String) readMeEntry;
+                    }
+                }
+            }
+
+            Optional<Config> projectGroupOpt = tomlFileConfig.getOptional(TomlUtils.PROJECT);
+            if (projectGroupOpt.isPresent()) {
+                Config projectGroupEntry = projectGroupOpt.get();
+                if (!projectGroupEntry.contains(TomlUtils.DYNAMIC)) {
+                    shouldExecute = true;
+                    addDynamicEntryToProject = true;
+                    logger.info("Adding to [{}] group entry! ({})", TomlUtils.PROJECT, TomlUtils.DYNAMIC);
+                } else {
+                    // if [project] has dynamic field, but it's missing one of the expected fields from the list
+                    Object dynamicEntry = projectGroupEntry.get(TomlUtils.DYNAMIC);
+                    // convert existing dynamic field to a List<String> so we can compare against expected values
+                    if (dynamicEntry instanceof List<?>) {
+                        for (Object entry : (List<?>) dynamicEntry) {
+                            if (entry instanceof String) {
+                                dynamicEntriesActual.add((String) entry);
+                            }
+                        }
+                    }
+                    // loop through expected entries and add missing ones
+                    for (String expectedEntry : dynamicEntriesExpected) {
+                        if (!dynamicEntriesActual.contains(expectedEntry)) {
+                            dynamicEntriesToAdd.add(expectedEntry);
+                        }
+                    }
+
+                    if (!dynamicEntriesToAdd.isEmpty()) {
+                        shouldExecute = true;
+                        appendEntriesToDynamic = true;
+                        logger.info("Adding additional fields to [{}] group entry! ({})", TomlUtils.DYNAMIC, dynamicEntriesToAdd);
+                    }
+                }
+            }
+        }
+        return shouldExecute;
+    }
+
+    @Override
+    protected boolean performMigration(File pyProjectTomlFile) {
+        boolean inProjectSection = false;
+        boolean inPoetrySection = false;
+        boolean injectedDynamicString = false;
+        boolean injectAfterNextEmptyLine = false;
+        boolean injectedDynamicList = false;
+        boolean injectedReadMeString = false;
+        String readMeString = TomlUtils.README + " " + TomlUtils.EQUALS + " " + TomlUtils.DOUBLE_QUOTE + readMeAsString + TomlUtils.DOUBLE_QUOTE;
+        StringBuilder fileContent = new StringBuilder();
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(pyProjectTomlFile))) {
+            String line = reader.readLine();
+
+            while (line != null) {
+                boolean isEmptyLine = line.isBlank();
+                boolean addLine = true;
+                String trimmedLine = line.strip();
+
+                // set flags to keep track of which header we're currently under
+                if (trimmedLine.startsWith("[") && trimmedLine.endsWith("]")){
+                    if (trimmedLine.equals("[" + TomlUtils.TOOL_POETRY + "]")){
+                        inPoetrySection = true;
+                        inProjectSection = false;
+                    } else if (trimmedLine.equals(("[" + TomlUtils.PROJECT + "]"))){
+                        inPoetrySection = false;
+                        inProjectSection = true;
+                    }
+                }
+
+                if (trimmedLine.contains(TomlUtils.EQUALS)){
+                    if(inProjectSection){
+                        if(addDynamicEntryToProject && !injectedDynamicString){
+                            injectAfterNextEmptyLine = true;
+                        } else if (addReadMeEntryToProject && !injectedReadMeString){
+                            injectAfterNextEmptyLine = true;
+                        } else if (appendEntriesToDynamic && !injectedDynamicList && trimmedLine.startsWith(TomlUtils.DYNAMIC)){
+                                addLine = false;
+                                fileContent.append(buildDynamicListString()).append("\n");
+                                injectedDynamicList = true;
+                            }
+                    } else if (inPoetrySection && addReadMeEntryToProject && trimmedLine.startsWith(TomlUtils.README)){
+                        // skip [tool.poetry.readme] line since it will be migrated to [project]
+                            addLine = false;
+                        }
+                }
+
+                if (isEmptyLine && injectAfterNextEmptyLine){
+                    if(addDynamicEntryToProject){
+                        fileContent.append(buildDynamicListString()).append("\n");
+                        injectAfterNextEmptyLine = false;
+                        injectedDynamicString = true;
+                    }
+                    if(addReadMeEntryToProject){
+                        fileContent.append(readMeString).append("\n");
+                        injectAfterNextEmptyLine = false;
+                        injectedReadMeString = true;
+                    }
+                }
+                if(addLine){
+                    fileContent.append(line).append("\n");
+                }
+                line = reader.readLine();
+            }
+        }catch (IOException e) {
+            throw new BatonException("Problem reading pyproject.toml for migration!", e);
+        }
+
+        try {
+            TomlUtils.writeTomlFile(pyProjectTomlFile, fileContent.toString());
+        } catch (IOException e) {
+            throw new BatonException("Problem writing updated pyproject.toml!", e);
+        }
+        return true;
+    }
+
+    protected String buildDynamicListString() {
+        List<String> listToUse;
+        if (addDynamicEntryToProject) {
+            listToUse = dynamicEntriesExpected;
+        } else {
+            listToUse = new ArrayList<>(dynamicEntriesActual);
+            listToUse.addAll(dynamicEntriesToAdd);
+        }
+        return TomlUtils.DYNAMIC + " " + TomlUtils.EQUALS + " [" + joinQuoted(listToUse) + "]";
+    }
+
+}

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryToProjectMigration.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryToProjectMigration.java
@@ -1,0 +1,160 @@
+package org.technologybrewery.habushu.migration.poetryv2migrations;
+
+import com.electronwill.nightconfig.core.Config;
+import com.electronwill.nightconfig.core.file.FileConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.technologybrewery.baton.BatonException;
+import org.technologybrewery.habushu.util.TomlReplacementTuple;
+import org.technologybrewery.habushu.util.TomlUtils;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.List;
+import java.util.Map;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+
+/**
+ * Provides functionality to migrate configuration entries from the [tool.poetry] section to the [project] section of a TOML file.
+ * Migrates any entry included in entriesToMigrate that does not already exist.
+ * Runs when on Poetry v2.0.0 or later.
+ */
+public class PoetryToProjectMigration extends AbstractPoetryMigration {
+    private static final Logger logger = LoggerFactory.getLogger(PoetryToProjectMigration.class);
+    private boolean hasProjectGroup = false;
+    private final List<String> entriesToMigrate = Arrays.asList("name", "description", "version", "authors", "maintainers", "license");
+    private final List<String> existingProjectKeys = new ArrayList<>();
+    private final Map<String, TomlReplacementTuple> replacements = new LinkedHashMap<>();
+
+    @Override
+    protected boolean shouldExecuteOnFile(File file) {
+        replacements.clear();
+        boolean shouldExecute = false;
+        Config.setInsertionOrderPreserved(true);
+
+        if (!isPoetryVersionAtLeast2) {
+            return false;
+        }
+
+        try (FileConfig tomlFileConfig = FileConfig.of(file)) {
+            tomlFileConfig.load();
+            Optional<Config> poetryGroupOpt = tomlFileConfig.getOptional(TomlUtils.TOOL_POETRY);
+
+            if (poetryGroupOpt.isPresent()){
+                Config poetryGroup = poetryGroupOpt.get();
+                for (Config.Entry groupEntry : poetryGroup.entrySet()) {
+
+                    // check if any of the entries under [tool.poetry] match one of "name", "description", or "version"
+                    String groupEntryName = groupEntry.getKey();
+                    Object groupEntryRhs = groupEntry.getValue();
+                    String groupEntryRhsAsString = null;
+
+                    if (entriesToMigrate.stream().anyMatch(e -> e.equalsIgnoreCase(groupEntryName))) {
+                        if (groupEntryRhs instanceof List<?>){
+                            List<String> listValues = poetryGroup.get(groupEntryName);
+                            List<String> listOfStrings = new ArrayList<>(listValues);
+                            groupEntryRhsAsString = convertListOfStringsToString(listOfStrings);
+                        } else {
+                            groupEntryRhsAsString = (String) groupEntryRhs;
+                        }
+
+                        logger.info("Found [{}] group entry to migrate! ({} = {})", TomlUtils.TOOL_POETRY, groupEntryName, groupEntryRhsAsString);
+                        TomlReplacementTuple replacementTuple = new TomlReplacementTuple(groupEntryName, groupEntryRhsAsString, "");
+                        replacements.put(groupEntryName, replacementTuple);
+                        shouldExecute = true;
+                    }
+                }
+            }
+            // process the [project] section and record existing keys
+            Optional<Config> projectGroupEntries = tomlFileConfig.getOptional(TomlUtils.PROJECT);
+            if (projectGroupEntries.isPresent()){
+                hasProjectGroup = true;
+                Config projectConfig = projectGroupEntries.get();
+                // iterate over the entries and add each key to the set
+                for (Config.Entry entry : projectConfig.entrySet()) {
+                    existingProjectKeys.add(entry.getKey());
+                }
+            }
+        }
+        return shouldExecute;
+    }
+
+    @Override
+    protected boolean performMigration(File pyProjectTomlFile) {
+        boolean injectAfterNextEmptyLine = false;
+        boolean inToolPoetrySection = false;
+        boolean inProjectSection = false;
+        boolean dependenciesInjected = false;
+        StringBuilder fileContent = new StringBuilder();
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(pyProjectTomlFile))) {
+            String line = reader.readLine();
+
+            while (line != null) {
+                boolean addLine = true;
+                boolean isEmptyLine = line.isBlank();
+                String trimmedLine = line.strip();
+
+                if (trimmedLine.startsWith("[") && trimmedLine.endsWith("]")){
+                    if (trimmedLine.equals("[" + TomlUtils.TOOL_POETRY + "]")) {
+                        inToolPoetrySection = true;
+                        inProjectSection = false;
+                    } else if (trimmedLine.equals(("[" + TomlUtils.PROJECT + "]"))) {
+                        inToolPoetrySection = false;
+                        inProjectSection = true;
+                    } else {
+                        inToolPoetrySection = false;
+                        inProjectSection = false;
+                    }
+                }
+                if (trimmedLine.contains(TomlUtils.EQUALS)) {
+                    if (inToolPoetrySection) {
+                        String key = line.substring(0, line.indexOf(TomlUtils.EQUALS)).strip();
+                        TomlReplacementTuple matchedTuple = replacements.get(key);
+                        if (matchedTuple != null) {
+                            // skip this line, we will add it back to [project] later
+                            addLine = false;
+                        }
+                    }
+                    if (!hasProjectGroup || (inProjectSection && !replacements.isEmpty())) {
+                        injectAfterNextEmptyLine = true;
+                    }
+                }
+                if (isEmptyLine && injectAfterNextEmptyLine){
+                    if (hasProjectGroup){
+                        fileContent = injectDependencies(fileContent, existingProjectKeys, replacements);
+                        dependenciesInjected = true;
+                        injectAfterNextEmptyLine = false;
+                    } else if (!dependenciesInjected){
+                        fileContent.append("\n[").append(TomlUtils.PROJECT).append("]\n");
+                        fileContent = injectDependencies(fileContent, existingProjectKeys, replacements);
+                        injectAfterNextEmptyLine = false;
+                        hasProjectGroup = true;
+                        dependenciesInjected = true;
+                    }
+                }
+                if (addLine) {
+                    fileContent.append(line).append("\n");
+                }
+
+                line = reader.readLine();
+            }
+        } catch (IOException e) {
+            throw new BatonException("Problem reading pyproject.toml for migration!", e);
+        }
+
+        try {
+            TomlUtils.writeTomlFile(pyProjectTomlFile, fileContent.toString());
+        } catch (IOException e) {
+            throw new BatonException("Problem writing updated pyproject.toml!", e);
+        }
+
+        return true;
+    }
+
+}

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryToProjectRequiresPythonMigration.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryToProjectRequiresPythonMigration.java
@@ -1,0 +1,128 @@
+package org.technologybrewery.habushu.migration.poetryv2migrations;
+
+import com.electronwill.nightconfig.core.Config;
+import com.electronwill.nightconfig.core.file.FileConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.technologybrewery.baton.BatonException;
+import org.technologybrewery.habushu.util.TomlUtils;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Optional;
+
+/**
+ * Provides functionality to migrate python dependency from the [tool.poetry.dependencies] section to the [project] section of a TOML file.
+ * Runs when on Poetry v2.0.0 or later.
+ */
+public class PoetryToProjectRequiresPythonMigration extends AbstractPoetryMigration{
+    private static final Logger logger = LoggerFactory.getLogger(PoetryToProjectRequiresPythonMigration.class);
+    private String pythonDependencyVersion;
+
+    @Override
+    protected boolean shouldExecuteOnFile(File file) {
+        boolean shouldExecute = false;
+
+        if (!isPoetryVersionAtLeast2){
+            return false;
+        }
+
+        try (FileConfig tomlFileConfig = FileConfig.of(file)){
+            tomlFileConfig.load();
+            Optional<Config> projectGroup = tomlFileConfig.getOptional(TomlUtils.PROJECT);
+
+            if (projectGroup.isPresent()){
+                Config projectGroupEntry = projectGroup.get();
+
+                if (!projectGroupEntry.contains(TomlUtils.REQUIRES_PYTHON)) {
+                    shouldExecute = true;
+                    logger.info("Adding to [{}] group entry! ({})", TomlUtils.PROJECT, TomlUtils.REQUIRES_PYTHON);
+                }
+
+                // grab original python dependency version from [tool.poetry.dependencies]
+                Optional<Config> poetryDependenciesGroup = tomlFileConfig.getOptional(TomlUtils.TOOL_POETRY_DEPENDENCIES);
+                if (poetryDependenciesGroup.isPresent()) {
+                    Config poetryDependenciesGroupEntry = poetryDependenciesGroup.get();
+                    if (poetryDependenciesGroupEntry.contains(TomlUtils.PYTHON)) {
+                        pythonDependencyVersion = poetryDependenciesGroupEntry.get(TomlUtils.PYTHON);
+                    }
+                }
+            }
+        }
+
+        return shouldExecute;
+    }
+
+    @Override
+    protected boolean performMigration(File pyProjectTomlFile) {
+        boolean inProjectSection = false;
+        boolean inPoetryDependenciesSection = false;
+        boolean injectedRequiresPython = false;
+        boolean injectAfterNextEmptyLine = false;
+        String requiresPythonLine = TomlUtils.REQUIRES_PYTHON + " " + TomlUtils.EQUALS + " " + TomlUtils.DOUBLE_QUOTE + pythonDependencyVersion + TomlUtils.DOUBLE_QUOTE;
+        StringBuilder fileContent = new StringBuilder();
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(pyProjectTomlFile))){
+            String line = reader.readLine();
+
+            while (line != null){
+                boolean isEmptyLine = line.isBlank();
+                boolean addLine = true;
+                String trimmedLine = line.strip();
+
+                if (trimmedLine.startsWith("[") && trimmedLine.endsWith("]")){
+                    if(trimmedLine.equals("[" + TomlUtils.PROJECT + "]")){
+                        inProjectSection = true;
+                        inPoetryDependenciesSection = false;
+                    } else if (trimmedLine.equals("[" + TomlUtils.TOOL_POETRY_DEPENDENCIES + "]")){
+                        inProjectSection = false;
+                        inPoetryDependenciesSection = true;
+                    } else {
+                        inProjectSection = false;
+                        inPoetryDependenciesSection = false;
+                    }
+                }
+                if (trimmedLine.contains(TomlUtils.EQUALS)) {
+                    if (inPoetryDependenciesSection) {
+                        // If in the [tool.poetry.dependencies] section, skip the line that defines the python dependency
+                        // considers cases where there are other dependencies whose name starts with 'python'
+                        int equalIndex = trimmedLine.indexOf(TomlUtils.EQUALS);
+                        String key = trimmedLine.substring(0, equalIndex).strip();
+
+                        // Only skip the line if the key exactly matches "python"
+                        if (key.equalsIgnoreCase(TomlUtils.PYTHON)) {
+                            addLine = false;
+                        }
+                    } else if (inProjectSection && !injectedRequiresPython){
+                        injectAfterNextEmptyLine = true;
+                    }
+                }
+                if (isEmptyLine && injectAfterNextEmptyLine ) {
+                    fileContent.append(requiresPythonLine).append("\n");
+                    injectedRequiresPython = true;
+                    injectAfterNextEmptyLine = false;
+                }
+
+                if (addLine) {
+                    fileContent.append(line).append("\n");
+                }
+
+                line = reader.readLine();
+            }
+
+        }catch (IOException e) {
+            throw new BatonException("Problem reading pyproject.toml for migration!", e);
+        }
+
+        try {
+            TomlUtils.writeTomlFile(pyProjectTomlFile, fileContent.toString());
+        } catch (IOException e) {
+            throw new BatonException("Problem writing updated pyproject.toml!", e);
+        }
+
+        return true;
+    }
+
+}

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/util/TomlUtils.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/util/TomlUtils.java
@@ -1,7 +1,9 @@
 package org.technologybrewery.habushu.util;
 
 import com.electronwill.nightconfig.core.CommentedConfig;
+import com.electronwill.nightconfig.core.concurrent.StampedConfig;
 import org.apache.commons.collections4.CollectionUtils;
+import org.technologybrewery.habushu.exec.PoetryCommandHelper;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -19,13 +21,20 @@ public final class TomlUtils {
 
     public static final String EQUALS = "=";
     public static final String DOUBLE_QUOTE = "\"";
+    public static final String TOOL_POETRY = "tool.poetry";
     public static final String TOOL_POETRY_DEPENDENCIES = "tool.poetry.dependencies";
     public static final String TOOL_POETRY_DEV_DEPENDENCIES = "tool.poetry.group.dev.dependencies";
     public static final String TOOL_POETRY_GROUP_MONOREPO_DEPENDENCIES = "tool.poetry.group.monorepo.dependencies";
+    public static final String PROJECT = "project";
     public static final String VERSION = "version";
     public static final String PATH = "path";
     public static final String DEVELOP = "develop";
     public static final String EXTRAS = "extras";
+    public static final String REQUIRES_PYTHON = "requires-python";
+    public static final String DYNAMIC = "dynamic";
+    public static final String PYTHON = "python";
+    public static final String README = "readme";
+    public static final String DEPENDENCIES = "dependencies";
 
     public static final String BUILD_SYSTEM = "build-system";
     public static final String REQUIRES = "requires";

--- a/habushu-maven-plugin/src/main/resources/migrations.json
+++ b/habushu-maven-plugin/src/main/resources/migrations.json
@@ -35,6 +35,51 @@
             ]
           }
         ]
+      },
+      {
+        "name": "poetry-v2-poetry-to-project-migration",
+        "implementation": "org.technologybrewery.habushu.migration.poetryv2migrations.PoetryToProjectMigration",
+        "fileSets": [
+          {
+            "includes": [
+              "pyproject.toml"
+            ],
+            "excludes": [
+              "**/habushu-mixology/pyproject.toml",
+              "**/habushu-mixology-consumer/pyproject.toml"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "poetry-v2-poetry-to-project-requires-python-migration",
+        "implementation": "org.technologybrewery.habushu.migration.poetryv2migrations.PoetryToProjectRequiresPythonMigration",
+        "fileSets": [
+          {
+            "includes": [
+              "pyproject.toml"
+            ],
+            "excludes": [
+              "**/habushu-mixology/pyproject.toml",
+              "**/habushu-mixology-consumer/pyproject.toml"
+            ]
+          }
+        ]
+      },
+      {
+        "name": "poetry-v2-poetry-to-project-dynamic-migration",
+        "implementation": "org.technologybrewery.habushu.migration.poetryv2migrations.PoetryToProjectDynamicMigration",
+        "fileSets": [
+          {
+            "includes": [
+              "pyproject.toml"
+            ],
+            "excludes": [
+              "**/habushu-mixology/pyproject.toml",
+              "**/habushu-mixology-consumer/pyproject.toml"
+            ]
+          }
+        ]
       }
     ]
   }

--- a/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/PoetryCommandHelperTestWrapper.java
+++ b/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/PoetryCommandHelperTestWrapper.java
@@ -2,20 +2,29 @@ package org.technologybrewery.habushu;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.technologybrewery.habushu.exec.PoetryCommandHelper;
 
 import java.io.File;
 
 public class PoetryCommandHelperTestWrapper extends PoetryCommandHelper {
     private final String mockPoetryVersion;
+    private static final String BREAKING_POETRY_VERSION = "2.0.0";
 
-    public PoetryCommandHelperTestWrapper(File workingDirectory, String mockPoetryVersion) {
-        super(workingDirectory);
+    public PoetryCommandHelperTestWrapper(File file, String mockPoetryVersion) {
+        super(file);
         this.mockPoetryVersion = mockPoetryVersion;
     }
 
     @Override
     public Pair<Boolean, String> getIsPoetryInstalledAndVersion() {
         return new ImmutablePair<>(true, mockPoetryVersion);
+    }
+
+    @Override
+    public boolean isPoetryVersionAtLeast2(){
+        DefaultArtifactVersion currentVersion = new DefaultArtifactVersion(mockPoetryVersion);
+        DefaultArtifactVersion minimumVersion = new DefaultArtifactVersion(BREAKING_POETRY_VERSION);
+        return currentVersion.compareTo(minimumVersion) >= 0;
     }
 }

--- a/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/migration/poetryv2migrations/AbstractPoetryMigrationSteps.java
+++ b/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/migration/poetryv2migrations/AbstractPoetryMigrationSteps.java
@@ -1,0 +1,92 @@
+package org.technologybrewery.habushu.migration.poetryv2migrations;
+
+import com.electronwill.nightconfig.core.Config;
+import com.electronwill.nightconfig.core.file.FileConfig;
+import org.technologybrewery.habushu.util.TomlUtils;
+
+import java.io.File;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class AbstractPoetryMigrationSteps{
+    protected static File testTomlFileDirectory = new File("./target/test-classes/migration/poetry-v2");
+    protected static File pyProjectToml;
+    protected Optional<Config> projectOpt;
+    protected Optional<Config> toolPoetryOpt;
+    protected Optional<Config> toolPoetryDependenciesOpt;
+    protected Config projectEntries;
+    protected Config toolPoetryEntries;
+    protected Config toolPoetryDependencyEntries;
+    protected boolean shouldExecute;
+    protected boolean executionSucceeded;
+
+    protected void verifyExecutionOccurred() {
+        assertTrue(shouldExecute, "Migration should have been selected to execute!");
+        assertTrue(executionSucceeded, "Migration should have executed successfully!");
+    }
+
+    protected int getNumberOfEntries(Config groupName) {
+        return groupName.entrySet().size();
+    }
+
+    protected static Optional<Config> getOptionalConfig(File file, String key){
+        try (FileConfig tomlFileConfig = FileConfig.of(file)) {
+            tomlFileConfig.load();
+            return tomlFileConfig.getOptional(key);
+        }
+    }
+
+    /**
+     * Helper method to check if entry exists within specified toml group
+     */
+    protected void assertKeyExists(String groupName, String key, boolean shouldExist) {
+        loadAndAssertGroupExists(groupName);
+
+        // Retrieve the appropriate entries based on groupName
+        Config entries;
+        if (groupName.equals(TomlUtils.PROJECT)) {
+            entries = projectEntries;
+        } else if (groupName.equals(TomlUtils.TOOL_POETRY)) {
+            entries = toolPoetryEntries;
+        } else if (groupName.equals(TomlUtils.TOOL_POETRY_DEPENDENCIES)) {
+            entries = toolPoetryDependencyEntries;
+        } else {
+            throw new IllegalArgumentException("Unknown group: " + groupName);
+        }
+
+        if (shouldExist) {
+            assertTrue(entries.contains(key), key + " should exist under " + groupName);
+        } else {
+            assertFalse(entries.contains(key), key + " should NOT exist under " + groupName);
+        }
+    }
+
+    /**
+     * Helper methods to load a toml group and assert its presence
+     */
+    protected void loadAndAssertGroupExists(String groupName) {
+        Optional<Config> groupOpt = getOptionalConfig(pyProjectToml, groupName);
+        assertTrue(groupOpt.isPresent(), groupName + " missing from toml file");
+        Config entries = groupOpt.get();
+
+        if (groupName.equals(TomlUtils.PROJECT)) {
+            projectOpt = groupOpt;
+            projectEntries = entries;
+        } else if (groupName.equals(TomlUtils.TOOL_POETRY)) {
+            toolPoetryOpt = groupOpt;
+            toolPoetryEntries = entries;
+        } else if (groupName.equals(TomlUtils.TOOL_POETRY_DEPENDENCIES)) {
+            toolPoetryDependenciesOpt = groupOpt;
+            toolPoetryDependencyEntries = entries;
+        } else {
+            throw new IllegalArgumentException("Unknown group: " + groupName);
+        }
+    }
+    protected void loadAndAssertDoesNotExist(String groupName) {
+        Optional<Config> groupOpt = getOptionalConfig(pyProjectToml, groupName);
+        assertFalse(groupOpt.isPresent(), groupName + " missing from toml file");
+    }
+
+}

--- a/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryToProjectDynamicMigrationSteps.java
+++ b/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryToProjectDynamicMigrationSteps.java
@@ -1,0 +1,137 @@
+package org.technologybrewery.habushu.migration.poetryv2migrations;
+
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.technologybrewery.habushu.PoetryCommandHelperTestWrapper;
+import org.technologybrewery.habushu.util.TomlUtils;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+public class PoetryToProjectDynamicMigrationSteps extends AbstractPoetryMigrationSteps {
+    private PoetryCommandHelperTestWrapper poetryHelper;
+    private boolean mockIsPoetryVersionAtLeast2;
+
+    @Given("Poetry version at least \"2.0.0\"")
+    public void poetry_version_at_least_2_0_0(){
+        poetryHelper = new PoetryCommandHelperTestWrapper(new File("."), "2.0.0");
+        mockIsPoetryVersionAtLeast2 = poetryHelper.isPoetryVersionAtLeast2();
+        assertTrue(mockIsPoetryVersionAtLeast2, "The Poetry version found was less than 2.0.0");
+    }
+
+    @Given("Poetry version less than \"2.0.0\"")
+    public void poetry_version_less_than_2_0_0(){
+        poetryHelper = new PoetryCommandHelperTestWrapper(new File("."), "1.6.1");
+        mockIsPoetryVersionAtLeast2 = poetryHelper.isPoetryVersionAtLeast2();
+        assertFalse(mockIsPoetryVersionAtLeast2, "The Poetry version found greater than 2.0.0");
+    }
+
+    @Given("an existing pyproject.toml file with no dynamic in project and no readme in tool.poetry")
+    public void an_existing_pyproject_toml_file_with_no_dynamic_in_project_and_no_readme_in_tool_poetry() {
+        pyProjectToml = new File(testTomlFileDirectory, "with-no-dynamic-in-project-and-no-readme-in-tool-poetry.toml");
+
+        assertKeyExists(TomlUtils.PROJECT, TomlUtils.DYNAMIC, false);
+        assertKeyExists(TomlUtils.TOOL_POETRY, TomlUtils.README, false);
+    }
+
+    @When("the Habushu poetry-to-project-dynamic migration executes")
+    public void the_habushu_poetry_to_project_dynamic_migration_executes() {
+        PoetryToProjectDynamicMigration migration = new PoetryToProjectDynamicMigration();
+        migration.setWorkingDirectory(new File("."));
+        migration.setIsPoetryVersionAtLeast2(mockIsPoetryVersionAtLeast2);
+
+        shouldExecute = migration.shouldExecuteOnFile(pyProjectToml);
+        executionSucceeded = (shouldExecute) ? migration.performMigration(pyProjectToml) : false;
+    }
+
+    @Then("the dynamic entry is added to the project group and contains")
+    public void the_dynamic_entry_with_readme_is_added_in_the_project_group_and_contains(DataTable dataTable) {
+        verifyExecutionOccurred();
+
+        assertKeyExists(TomlUtils.PROJECT, TomlUtils.DYNAMIC, true);
+
+        List<String> expectedEntries = dataTable.asList(String.class);
+        Object actualEntries = projectEntries.get(TomlUtils.DYNAMIC);
+        assertEquals(expectedEntries.toString(), actualEntries.toString(), "Mismatch in expected readme values");
+    }
+
+    @Given("an existing pyproject.toml file with no dynamic in project and with a single readme in tool.poetry")
+    public void an_existing_pyproject_toml_file_with_no_dynamic_in_project_and_with_a_single_readme_in_tool_poetry() {
+        pyProjectToml = new File(testTomlFileDirectory, "with-no-dynamic-in-project-and-with-single-readme-in-tool-poetry.toml");
+
+        assertKeyExists(TomlUtils.PROJECT, TomlUtils.DYNAMIC, false);
+        assertKeyExists(TomlUtils.TOOL_POETRY, TomlUtils.README, true);
+
+        Object readMeEntry = toolPoetryEntries.get(TomlUtils.README);
+        assertInstanceOf(String.class, readMeEntry, "[tool.poetry] readme does not contain single string value as expected");
+    }
+
+    @Then("the readme entry is added to the project group as {string}")
+    public void the_readme_entry_is_added_in_the_project_group(String expectedReadMeEntry) {
+        assertKeyExists(TomlUtils.PROJECT, TomlUtils.README, true);
+        assertEquals(expectedReadMeEntry, projectEntries.get(TomlUtils.README).toString(), "readme was set incorrectly in [project]");
+    }
+
+    @Then("the readme entry is removed from the tool.poetry group")
+    public void the_readme_entry_is_removed_from_the_tool_poetry_group() {
+        assertKeyExists(TomlUtils.TOOL_POETRY, TomlUtils.README, false);
+    }
+
+    @Given("an existing pyproject.toml file with no dynamic in project and with multiple readmes in tool.poetry")
+    public void an_existing_pyproject_toml_file_with_no_dynamic_in_project_and_multiple_readmes_in_tool_poetry() {
+        pyProjectToml = new File(testTomlFileDirectory, "with-no-dynamic-in-project-and-with-multiple-readmes-in-tool-poetry.toml");
+
+        assertKeyExists(TomlUtils.PROJECT, TomlUtils.DYNAMIC, false);
+        assertKeyExists(TomlUtils.TOOL_POETRY, TomlUtils.README, true);
+
+        Object readMeEntries = toolPoetryEntries.get(TomlUtils.README);
+        assertInstanceOf(ArrayList.class, readMeEntries, "[tool.poetry] readme does not contain multiple values as expected");
+    }
+
+    @Then("the readme entry remains in the tool.poetry group and contains")
+    public void the_readme_entry_remains_in_the_tool_poetry_group_and_contains(DataTable dataTable) {
+        assertKeyExists(TomlUtils.TOOL_POETRY, TomlUtils.README, true);
+
+        List<String> expectedEntries = dataTable.asList(String.class);
+        Object actualEntries = toolPoetryEntries.get(TomlUtils.README);
+        assertEquals(expectedEntries.toString(), actualEntries.toString(), "Mismatch in expected readme values");
+    }
+
+    @Given("an existing pyproject.toml file with a dynamic entry but missing required field in project")
+    public void an_existing_pyproject_toml_file_with_a_dynamic_entry_but_missing_required_field_in_project(DataTable dataTable) {
+        pyProjectToml = new File(testTomlFileDirectory, "with-dynamic-in-project-but-missing-required-field.toml");
+        assertKeyExists(TomlUtils.PROJECT, TomlUtils.DYNAMIC, true);
+
+        List<String> expectedEntries = dataTable.asList(String.class);
+        Object actualEntries = projectEntries.get(TomlUtils.DYNAMIC);
+        assertEquals(expectedEntries.toString(), actualEntries.toString(), "Mismatch in expected dynamic values");
+    }
+
+    @Then("the missing field is appended to the dynamic entry and now contains")
+    public void the_missing_field_is_appended_to_the_dynamic_entry_and_contains(DataTable dataTable) {
+        assertKeyExists(TomlUtils.PROJECT, TomlUtils.DYNAMIC, true);
+
+        List<String> expectedEntries = dataTable.asList(String.class);
+        Object actualEntries = projectEntries.get(TomlUtils.DYNAMIC);
+        assertEquals(expectedEntries.toString(), actualEntries.toString());
+    }
+
+    @Given("an existing pyproject.toml file with no dynamic in project")
+    public void an_existing_pyproject_toml_file_with_no_dynamic_in_project() {
+        pyProjectToml = new File(testTomlFileDirectory, "no-poetry-to-project-dynamic-migration.toml");
+        assertKeyExists(TomlUtils.PROJECT, TomlUtils.DYNAMIC, false);
+    }
+    @Then("the poetry to project dynamic migration did not execute")
+    public void the_poetry_to_project_requires_python_migration_did_not_execute() {
+        assertFalse(shouldExecute, "Migration execution should have been skipped!");
+    }
+
+}

--- a/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryToProjectMigrationSteps.java
+++ b/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryToProjectMigrationSteps.java
@@ -1,0 +1,87 @@
+package org.technologybrewery.habushu.migration.poetryv2migrations;
+
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.technologybrewery.habushu.PoetryCommandHelperTestWrapper;
+import org.technologybrewery.habushu.util.TomlUtils;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PoetryToProjectMigrationSteps extends AbstractPoetryMigrationSteps {
+    protected PoetryCommandHelperTestWrapper poetryHelper;
+    protected boolean mockIsPoetryVersionAtLeast2;
+
+    @Given("the Poetry version is at least \"2.0.0\"")
+    public void the_poetry_version_is_at_least_2_0_0(){
+        poetryHelper = new PoetryCommandHelperTestWrapper(new File("."), "2.0.0");
+        mockIsPoetryVersionAtLeast2 = poetryHelper.isPoetryVersionAtLeast2();
+        assertTrue(mockIsPoetryVersionAtLeast2, "The Poetry version found was less than 2.0.0");
+    }
+
+    @Given("the Poetry version is less than \"2.0.0\"")
+    public void poetry_version_is_less_than_2_0_0(){
+        poetryHelper = new PoetryCommandHelperTestWrapper(new File("."), "1.6.1");
+        mockIsPoetryVersionAtLeast2 = poetryHelper.isPoetryVersionAtLeast2();
+        assertFalse(mockIsPoetryVersionAtLeast2, "The Poetry version found greater than 2.0.0");
+    }
+
+    @Given("an existing pyproject.toml file with entries in the tool.poetry group")
+    public void an_existing_pyproject_toml_file_with_entries_in_the_tool_poetry_group() {
+        pyProjectToml = new File(testTomlFileDirectory, "with-fields-in-tool-poetry.toml");
+        loadAndAssertGroupExists(TomlUtils.TOOL_POETRY);
+    }
+
+    @When("the Habushu poetry-to-project migration executes")
+    public void the_habushu_poetry_to_project_migration_executes() {
+        PoetryToProjectMigration migration = new PoetryToProjectMigration();
+        migration.setWorkingDirectory(new File("."));
+        migration.setIsPoetryVersionAtLeast2(mockIsPoetryVersionAtLeast2);
+
+        shouldExecute = migration.shouldExecuteOnFile(pyProjectToml);
+        executionSucceeded = (shouldExecute) ? migration.performMigration(pyProjectToml) : false;
+    }
+
+    @Then("{int} entries exist in the tool.poetry group")
+    public void entries_exist_in_the_tool_poetry_group(Integer expectedToolPoetryEntries) {
+        verifyExecutionOccurred();
+        loadAndAssertGroupExists(TomlUtils.TOOL_POETRY);
+
+        int actualEntries = getNumberOfEntries(toolPoetryEntries);
+        assertEquals(expectedToolPoetryEntries, actualEntries,
+                expectedToolPoetryEntries + " entries should remain in the tool.poetry group!");
+    }
+
+    @Then("{int} entries exist in the project group")
+    public void entries_exist_in_the_project_group(Integer expectedProjectEntries) {
+        loadAndAssertGroupExists(TomlUtils.PROJECT);
+
+        int actualEntries = getNumberOfEntries(projectEntries);
+        assertEquals(expectedProjectEntries, actualEntries,
+                expectedProjectEntries + " entries should remain in the project group!");
+    }
+
+    @Given("an existing pyproject.toml file with overlapping entries between the tool.poetry and project groups")
+    public void an_existing_pyproject_toml_file_with_overlapping_entries_between_groups() {
+        pyProjectToml = new File(testTomlFileDirectory, "with-overlapping-fields-in-tool-poetry-and-project.toml");
+        loadAndAssertGroupExists(TomlUtils.TOOL_POETRY);
+    }
+
+
+    @Given("an existing pyproject.toml file with no project group")
+    public void an_existing_pyproject_toml_file_with_no_project_group() {
+        pyProjectToml = new File(testTomlFileDirectory, "no-poetry-to-project-migration.toml");
+        loadAndAssertDoesNotExist(TomlUtils.PROJECT);
+    }
+
+    @Then("the poetry to project migration did not execute")
+    public void the_poetry_to_project_migration_did_not_execute() {
+        assertFalse(shouldExecute, "Migration execution should have been skipped!");
+    }
+
+}
+

--- a/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryToProjectRequiresPythonMigrationSteps.java
+++ b/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryToProjectRequiresPythonMigrationSteps.java
@@ -1,0 +1,79 @@
+package org.technologybrewery.habushu.migration.poetryv2migrations;
+
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.technologybrewery.habushu.PoetryCommandHelperTestWrapper;
+import org.technologybrewery.habushu.util.TomlUtils;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PoetryToProjectRequiresPythonMigrationSteps extends AbstractPoetryMigrationSteps {
+    private PoetryCommandHelperTestWrapper poetryHelper;
+    private boolean mockIsPoetryVersionAtLeast2;
+
+    @Given("Poetry version is at least \"2.0.0\"")
+    public void poetry_version_is_at_least_2_0_0(){
+        poetryHelper = new PoetryCommandHelperTestWrapper(new File("."), "2.0.0");
+        mockIsPoetryVersionAtLeast2 = poetryHelper.isPoetryVersionAtLeast2();
+        assertTrue(mockIsPoetryVersionAtLeast2, "The Poetry version found was less than 2.0.0");
+    }
+
+    @Given("Poetry version is less than \"2.0.0\"")
+    public void poetry_version_is_less_than_2_0_0(){
+        poetryHelper = new PoetryCommandHelperTestWrapper(new File("."), "1.6.1");
+        mockIsPoetryVersionAtLeast2 = poetryHelper.isPoetryVersionAtLeast2();
+        assertFalse(mockIsPoetryVersionAtLeast2, "The Poetry version found greater than 2.0.0");
+    }
+
+    @Given("an existing pyproject.toml file with no requires-python entry in the project group")
+    public void an_existing_pyproject_toml_file_with_no_requires_python_entry_in_the_project_group() {
+        pyProjectToml = new File(testTomlFileDirectory, "with-no-requires-python-in-project.toml");
+        assertKeyExists(TomlUtils.PROJECT, TomlUtils.REQUIRES_PYTHON, false);
+    }
+
+    @When("the Habushu poetry-to-project-requires-python migration executes")
+    public void the_habushu_poetry_to_project_requires_python_migration_executes() {
+        PoetryToProjectRequiresPythonMigration migration = new PoetryToProjectRequiresPythonMigration();
+        migration.setWorkingDirectory(new File("."));
+        migration.setIsPoetryVersionAtLeast2(mockIsPoetryVersionAtLeast2);
+
+        shouldExecute = migration.shouldExecuteOnFile(pyProjectToml);
+        executionSucceeded = (shouldExecute) ? migration.performMigration(pyProjectToml) : false;
+    }
+
+    @Then("the requires-python entry is added to the project group and set to {string}")
+    public void the_requires_python_entry_is_added_to_the_project_group_and_set_to(String expectedPythonVersion) {
+        verifyExecutionOccurred();
+
+        assertKeyExists(TomlUtils.PROJECT, TomlUtils.REQUIRES_PYTHON, true);
+        assertEquals(expectedPythonVersion, projectEntries.get(TomlUtils.REQUIRES_PYTHON).toString(),"requires-python was set incorrectly in [project]");
+    }
+
+    @Then("the python entry no longer exists in the tool.poetry.dependencies group")
+    public void the_python_entry_no_longer_exists_in_the_tool_poetry_group() {
+        assertKeyExists(TomlUtils.TOOL_POETRY_DEPENDENCIES, TomlUtils.PYTHON, false);
+    }
+
+    @Given("an existing pyproject.toml file with a requires-python entry in the project group")
+    public void an_existing_pyproject_toml_file_with_a_requires_python_entry_in_project_group() {
+        pyProjectToml = new File(testTomlFileDirectory, "with-requires-python-in-project.toml");
+        assertKeyExists(TomlUtils.PROJECT, TomlUtils.REQUIRES_PYTHON, true);
+    }
+
+    @Given("an existing pyproject.toml file with no requires-python")
+    public void an_existing_pyproject_toml_file_without_a_requires_python_entry_in_project_group() {
+        pyProjectToml = new File(testTomlFileDirectory, "no-poetry-to-project-requires-python-migration.toml");
+        assertKeyExists(TomlUtils.PROJECT, TomlUtils.REQUIRES_PYTHON, false);
+    }
+
+    @Then("the poetry to project requires python migration did not execute")
+    public void the_poetry_to_project_requires_python_migration_did_not_execute() {
+        assertFalse(shouldExecute, "Migration execution should have been skipped!");
+    }
+
+}

--- a/habushu-maven-plugin/src/test/resources/migration/poetry-v2/no-poetry-to-project-dynamic-migration.toml
+++ b/habushu-maven-plugin/src/test/resources/migration/poetry-v2/no-poetry-to-project-dynamic-migration.toml
@@ -1,0 +1,24 @@
+[project]
+name = "no-poetry-to-project-dynamic-migration"
+description = "Test skipping poetry-to-project-dynamic migration when Poetry version is less than 2.0.0"
+version = "2.9.0.dev"
+authors = [{name = "Test", email = "blah@foobar.com"}]
+maintainers = [{name = "Test", email = "blah@foobar.com"}]
+license = "MIT License"
+
+[tool.poetry]
+packages = [{include = "example_1", from = "src"}]
+readme = "README.md"
+
+[tool.poetry.dependencies]
+krausening = "19"
+cryptography = "^42.0.0"
+uvicorn = {version = "^0.18.0", extras = ["standard"]}
+
+[tool.poetry.group.dev.dependencies]
+kappa-maki = ">=1.0.0"
+pylint = ">=3.1.0"
+
+[build-system]
+requires = ["poetry-core>=1.6.0"]
+build-backend = "poetry.core.masonry.api"

--- a/habushu-maven-plugin/src/test/resources/migration/poetry-v2/no-poetry-to-project-migration.toml
+++ b/habushu-maven-plugin/src/test/resources/migration/poetry-v2/no-poetry-to-project-migration.toml
@@ -1,0 +1,22 @@
+[tool.poetry]
+name = "no-poetry-to-project-migration"
+description = "Test skipping poetry-to-project migration when Poetry version is less than 2.0.0"
+version = "2.9.0.dev"
+authors = ["Test <blah@foobar.com>"]
+maintainers = ["Test <blah@foobar.com>"]
+license = "MIT License"
+packages = [{include = "example_1", from = "src"}]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+krausening = "19"
+cryptography = "^42.0.0"
+uvicorn = {version = "^0.18.0", extras = ["standard"]}
+
+[tool.poetry.group.dev.dependencies]
+kappa-maki = ">=1.0.0"
+pylint = ">=3.1.0"
+
+[build-system]
+requires = ["poetry-core>=1.6.0"]
+build-backend = "poetry.core.masonry.api"

--- a/habushu-maven-plugin/src/test/resources/migration/poetry-v2/no-poetry-to-project-requires-python-migration.toml
+++ b/habushu-maven-plugin/src/test/resources/migration/poetry-v2/no-poetry-to-project-requires-python-migration.toml
@@ -1,0 +1,24 @@
+[project]
+name = "no-poetry-to-project-requires-python-migration"
+description = "Test skipping poetry-to-project-requires-python migration when Poetry version is less than 2.0.0"
+version = "2.9.0.dev"
+authors = [{name = "Test", email = "blah@foobar.com"}]
+maintainers = [{name = "Test", email = "blah@foobar.com"}]
+license = "MIT License"
+
+[tool.poetry]
+packages = [{include = "example_1", from = "src"}]
+readme = "README.md"
+
+[tool.poetry.dependencies]
+krausening = "19"
+cryptography = "^42.0.0"
+uvicorn = {version = "^0.18.0", extras = ["standard"]}
+
+[tool.poetry.group.dev.dependencies]
+kappa-maki = ">=1.0.0"
+pylint = ">=3.1.0"
+
+[build-system]
+requires = ["poetry-core>=1.6.0"]
+build-backend = "poetry.core.masonry.api"

--- a/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-dynamic-in-project-but-missing-required-field.toml
+++ b/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-dynamic-in-project-but-missing-required-field.toml
@@ -1,0 +1,25 @@
+[project]
+name = "with-dynamic-in-project-but-missing-required-field"
+description = "Test appending missing required field to existing dynamic entry in project when Poetry version is at least 2.0.0"
+version = "2.9.0.dev"
+authors = [{name = "Test", email = "blah@foobar.com"}]
+maintainers = [{name = "Test", email = "blah@foobar.com"}]
+license = "MIT License"
+requires-python = "^3.11"
+dynamic = ["version"]
+
+[tool.poetry]
+packages = [{include = "example_1", from = "src"}]
+
+[tool.poetry.dependencies]
+krausening = "19"
+cryptography = "^42.0.0"
+uvicorn = {version = "^0.18.0", extras = ["standard"]}
+
+[tool.poetry.group.dev.dependencies]
+kappa-maki = ">=1.0.0"
+pylint = ">=3.1.0"
+
+[build-system]
+requires = ["poetry-core>=1.6.0"]
+build-backend = "poetry.core.masonry.api"

--- a/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-fields-in-tool-poetry.toml
+++ b/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-fields-in-tool-poetry.toml
@@ -1,0 +1,22 @@
+[tool.poetry]
+name = "with-fields-in-tool-poetry"
+description = "Test moving entries from tool.poetry to project when Poetry version is at least 2.0.0"
+version = "2.9.0.dev"
+authors = ["Test <blah@foobar.com>"]
+maintainers = ["Test <blah@foobar.com>"]
+license = "MIT License"
+packages = [{include = "example_1", from = "src"}]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+krausening = "19"
+cryptography = "^42.0.0"
+uvicorn = {version = "^0.18.0", extras = ["standard"]}
+
+[tool.poetry.group.dev.dependencies]
+kappa-maki = ">=1.0.0"
+pylint = ">=3.1.0"
+
+[build-system]
+requires = ["poetry-core>=1.6.0"]
+build-backend = "poetry.core.masonry.api"

--- a/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-no-dynamic-in-project-and-no-readme-in-tool-poetry.toml
+++ b/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-no-dynamic-in-project-and-no-readme-in-tool-poetry.toml
@@ -1,0 +1,24 @@
+[project]
+name = "with-no-dynamic-in-project-and-no-readme-in-tool-poetry"
+description = "Test adding dynamic entry to project when Poetry version is at least 2.0.0 and no readme in tool.poetry"
+version = "2.9.0.dev"
+authors = [{name = "Test", email = "blah@foobar.com"}]
+maintainers = [{name = "Test", email = "blah@foobar.com"}]
+license = "MIT License"
+requires-python = "^3.11"
+
+[tool.poetry]
+packages = [{include = "example_1", from = "src"}]
+
+[tool.poetry.dependencies]
+krausening = "19"
+cryptography = "^42.0.0"
+uvicorn = {version = "^0.18.0", extras = ["standard"]}
+
+[tool.poetry.group.dev.dependencies]
+kappa-maki = ">=1.0.0"
+pylint = ">=3.1.0"
+
+[build-system]
+requires = ["poetry-core>=1.6.0"]
+build-backend = "poetry.core.masonry.api"

--- a/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-no-dynamic-in-project-and-with-multiple-readmes-in-tool-poetry.toml
+++ b/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-no-dynamic-in-project-and-with-multiple-readmes-in-tool-poetry.toml
@@ -1,0 +1,25 @@
+[project]
+name = "with-no-dynamic-in-project-and-with-multiple-readmes-in-tool-poetry"
+description = "Test adding dynamic entry to project when Poetry version is at least 2.0.0 and multiple readmes in tool.poetry"
+version = "2.9.0.dev"
+authors = [{name = "Test", email = "blah@foobar.com"}]
+maintainers = [{name = "Test", email = "blah@foobar.com"}]
+license = "MIT License"
+requires-python = "^3.11"
+
+[tool.poetry]
+packages = [{include = "example_1", from = "src"}]
+readme = ["README.md", "src/example_1/README.md"]
+
+[tool.poetry.dependencies]
+krausening = "19"
+cryptography = "^42.0.0"
+uvicorn = {version = "^0.18.0", extras = ["standard"]}
+
+[tool.poetry.group.dev.dependencies]
+kappa-maki = ">=1.0.0"
+pylint = ">=3.1.0"
+
+[build-system]
+requires = ["poetry-core>=1.6.0"]
+build-backend = "poetry.core.masonry.api"

--- a/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-no-dynamic-in-project-and-with-single-readme-in-tool-poetry.toml
+++ b/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-no-dynamic-in-project-and-with-single-readme-in-tool-poetry.toml
@@ -1,0 +1,25 @@
+[project]
+name = "with-no-dynamic-in-project-and-single-readme-in-tool-poetry"
+description = "Test adding dynamic entry to project when Poetry version is at least 2.0.0 and a single readme in tool.poetry"
+version = "2.9.0.dev"
+authors = [{name = "Test", email = "blah@foobar.com"}]
+maintainers = [{name = "Test", email = "blah@foobar.com"}]
+license = "MIT License"
+requires-python = "^3.11"
+
+[tool.poetry]
+packages = [{include = "example_1", from = "src"}]
+readme = "README.md"
+
+[tool.poetry.dependencies]
+krausening = "19"
+cryptography = "^42.0.0"
+uvicorn = {version = "^0.18.0", extras = ["standard"]}
+
+[tool.poetry.group.dev.dependencies]
+kappa-maki = ">=1.0.0"
+pylint = ">=3.1.0"
+
+[build-system]
+requires = ["poetry-core>=1.6.0"]
+build-backend = "poetry.core.masonry.api"

--- a/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-no-requires-python-in-project.toml
+++ b/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-no-requires-python-in-project.toml
@@ -1,0 +1,26 @@
+[project]
+name = "with-no-requires-python-in-project"
+description = "Test adding requires-python entry to project when Poetry version is at least 2.0.0 and python dependency exists in tool.poetry.dependencies"
+version = "2.9.0.dev"
+authors = [{name = "Test", email = "blah@foobar.com"}]
+maintainers = [{name = "Test", email = "blah@foobar.com"}]
+license = "MIT License"
+dynamic = ["version", "dependencies"]
+
+[tool.poetry]
+packages = [{include = "example_1", from = "src"}]
+readme = ["README.md"]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+krausening = "19"
+cryptography = "^42.0.0"
+uvicorn = {version = "^0.18.0", extras = ["standard"]}
+
+[tool.poetry.group.dev.dependencies]
+kappa-maki = ">=1.0.0"
+pylint = ">=3.1.0"
+
+[build-system]
+requires = ["poetry-core>=1.6.0"]
+build-backend = "poetry.core.masonry.api"

--- a/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-overlapping-fields-in-tool-poetry-and-project.toml
+++ b/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-overlapping-fields-in-tool-poetry-and-project.toml
@@ -1,0 +1,26 @@
+[tool.poetry]
+name = "with-overlapping-fields-in-tool-poetry-and-project"
+description = "Test moving entries from tool.poetry to project when Poetry version is at least 2.0.0 and there are overlapping fields between tool.poetry and project"
+version = "2.9.0.dev"
+authors = ["Test <blah@foobar.com>"]
+maintainers = ["Test <blah@foobar.com>"]
+license = "MIT License"
+packages = [{include = "example_1", from = "src"}]
+
+[project]
+name = "Project-with-overlapping-fields-in-tool-poetry-and-project"
+description = "Project description already exists!"
+
+[tool.poetry.dependencies]
+python = "^3.11"
+krausening = "19"
+cryptography = "^42.0.0"
+uvicorn = {version = "^0.18.0", extras = ["standard"]}
+
+[tool.poetry.group.dev.dependencies]
+kappa-maki = ">=1.0.0"
+pylint = ">=3.1.0"
+
+[build-system]
+requires = ["poetry-core>=1.6.0"]
+build-backend = "poetry.core.masonry.api"

--- a/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-requires-python-in-project.toml
+++ b/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-requires-python-in-project.toml
@@ -1,0 +1,25 @@
+[project]
+name = "with-requires-python-in-project"
+description = "Test skipping migration when requires-python entry already exists under project"
+version = "2.9.0.dev"
+authors = [{name = "Test", email = "blah@foobar.com"}]
+maintainers = [{name = "Test", email = "blah@foobar.com"}]
+license = "MIT License"
+dynamic = ["version", "dependencies"]
+requires-python = "^3.11"
+
+[tool.poetry]
+packages = [{include = "example_1", from = "src"}]
+
+[tool.poetry.dependencies]
+krausening = "19"
+cryptography = "^42.0.0"
+uvicorn = {version = "^0.18.0", extras = ["standard"]}
+
+[tool.poetry.group.dev.dependencies]
+kappa-maki = ">=1.0.0"
+pylint = ">=3.1.0"
+
+[build-system]
+requires = ["poetry-core>=1.6.0"]
+build-backend = "poetry.core.masonry.api"

--- a/habushu-maven-plugin/src/test/resources/specifications/poetry-v2/poetry-to-project-dynamic-migration.feature
+++ b/habushu-maven-plugin/src/test/resources/specifications/poetry-v2/poetry-to-project-dynamic-migration.feature
@@ -1,0 +1,47 @@
+@poetryToProjectDynamicMigration
+Feature: Test automatic addition of dynamic field to [project] section of pyproject.toml file for projects using Poetry version of at least 2.0.0
+
+  Scenario: Poetry version is at least 2.0.0 and [project] section does not have dynamic entry and [tool.poetry] does not have a readme so only dynamic = ["version", "dependencies"] is injected
+    Given Poetry version at least "2.0.0"
+    And an existing pyproject.toml file with no dynamic in project and no readme in tool.poetry
+    When the Habushu poetry-to-project-dynamic migration executes
+    Then the dynamic entry is added to the project group and contains
+      | version      |
+      | dependencies |
+
+  Scenario: Poetry version is at least 2.0.0 and [project] section does not have dynamic entry and [tool.poetry] has a single readme so dynamic = ["version", "dependencies"] is injected and readme is migrated from [tool.poetry] to [project]
+    Given Poetry version at least "2.0.0"
+    And an existing pyproject.toml file with no dynamic in project and with a single readme in tool.poetry
+    When the Habushu poetry-to-project-dynamic migration executes
+    Then the dynamic entry is added to the project group and contains
+      | version      |
+      | dependencies |
+    And the readme entry is added to the project group as "README.md"
+    And the readme entry is removed from the tool.poetry group
+
+  Scenario: Poetry version is at least 2.0.0 and [project] section does not have dynamic entry and [tool.poetry] has multiple readmes so dynamic = ["version", "dependencies", "readme"] is injected and the readmes remains in tool.poetry
+    Given Poetry version at least "2.0.0"
+    And an existing pyproject.toml file with no dynamic in project and with multiple readmes in tool.poetry
+    When the Habushu poetry-to-project-dynamic migration executes
+    Then the dynamic entry is added to the project group and contains
+      | version       |
+      | dependencies  |
+      | readme        |
+    And the readme entry remains in the tool.poetry group and contains
+      | README.md                |
+      | src/example_1/README.md  |
+
+  Scenario: Poetry version is at least 2.0.0 and [project] section has a dynamic entry but it is missing one of the required fields so the missing field is appended to the existing dynamic list. For example dynamic = ["version"] becomes dynamic = ["version", "dependencies"].
+    Given Poetry version at least "2.0.0"
+    And an existing pyproject.toml file with a dynamic entry but missing required field in project
+      |version       |
+    When the Habushu poetry-to-project-dynamic migration executes
+    Then the missing field is appended to the dynamic entry and now contains
+      | version      |
+      | dependencies |
+
+  Scenario: Poetry version is less than 2.0.0 and the poetry-to-project-dynamic migration does not execute
+    Given Poetry version less than "2.0.0"
+    And an existing pyproject.toml file with no dynamic in project
+    When the Habushu poetry-to-project migration executes
+    Then the poetry to project dynamic migration did not execute

--- a/habushu-maven-plugin/src/test/resources/specifications/poetry-v2/poetry-to-project-migration.feature
+++ b/habushu-maven-plugin/src/test/resources/specifications/poetry-v2/poetry-to-project-migration.feature
@@ -1,0 +1,30 @@
+@poetryToProjectMigration
+Feature: Test automatic migrations of required fields from [tool.project] to [project] applied to pyproject.toml file based on given Poetry version
+
+  Scenario Outline: Poetry version is at least 2.0.0 and the poetry-to-project migration moves fields from [tool.poetry] to [project]
+    Given the Poetry version is at least "2.0.0"
+    And an existing pyproject.toml file with entries in the tool.poetry group
+    When the Habushu poetry-to-project migration executes
+    Then <expectedToolPoetryEntries> entries exist in the tool.poetry group
+    And <expectedProjectEntries> entries exist in the project group
+
+    Examples:
+      | expectedToolPoetryEntries | expectedProjectEntries |
+      | 3                         | 6                      |
+
+  Scenario Outline: Poetry version is at least 2.0.0 and there are overlapping fields between [tool.poetry] and [project]. Then, the poetry-to-project migration only migrates fields from [tool.poetry] that do not already exist in [project]
+    Given the Poetry version is at least "2.0.0"
+    And an existing pyproject.toml file with overlapping entries between the tool.poetry and project groups
+    When the Habushu poetry-to-project migration executes
+    Then <expectedToolPoetryEntries> entries exist in the tool.poetry group
+    And <expectedProjectEntries> entries exist in the project group
+
+    Examples:
+      | expectedToolPoetryEntries | expectedProjectEntries |
+      | 3                         | 6                      |
+
+  Scenario: Poetry version is less than 2.0.0 and the poetry-to-project migration does not execute
+    Given the Poetry version is less than "2.0.0"
+    And an existing pyproject.toml file with no project group
+    When the Habushu poetry-to-project migration executes
+    Then the poetry to project migration did not execute

--- a/habushu-maven-plugin/src/test/resources/specifications/poetry-v2/poetry-to-project-requires-python-migration.feature
+++ b/habushu-maven-plugin/src/test/resources/specifications/poetry-v2/poetry-to-project-requires-python-migration.feature
@@ -1,0 +1,21 @@
+@poetryToProjectRequiresPythonMigration
+Feature: Test automatic migrations of python dependency from [tool.project] to [project] applied to pyproject.toml file based on given Poetry version
+
+  Scenario: Poetry version is at least 2.0.0 and the poetry-to-project-requires-python migration adds a new requires-python entry to [project] group and removes the python dependency from [tool.poetry.dependencies] group
+    Given Poetry version is at least "2.0.0"
+    And an existing pyproject.toml file with no requires-python entry in the project group
+    When the Habushu poetry-to-project-requires-python migration executes
+    Then the requires-python entry is added to the project group and set to "^3.11"
+    And the python entry no longer exists in the tool.poetry.dependencies group
+
+  Scenario: Poetry version is at least 2.0.0 and project group already has a requires-python entry so the migration does not execute
+    Given Poetry version is at least "2.0.0"
+    And an existing pyproject.toml file with a requires-python entry in the project group
+    When the Habushu poetry-to-project-requires-python migration executes
+    Then the poetry to project requires python migration did not execute
+
+  Scenario: Poetry version is less than 2.0.0 so the migration does not execute
+    Given Poetry version is less than "2.0.0"
+    And an existing pyproject.toml file with no requires-python
+    When the Habushu poetry-to-project-requires-python migration executes
+    Then the poetry to project requires python migration did not execute


### PR DESCRIPTION
- Creates 3 new baton migrations associated with Poetry v2.0.0 and PEP 621 support
1. `PoetryToProjectMigration`: Adds `[project]` section into TOML file and moves relevant fields from `[tool.poetry]` to `[project]`
2. `PoetryToProjectRequiresPythonMigration`: Relocates the Python dependency from `[tool.poetry.dependencies]` to the `requires-python` entry under `[project]`
3. `PoetryToProjectDynamicMigration`: Introduces a `dynamic` field under `[project]` that automatically includes `version` and `dependency`, if not already present. If a single `readme` (as a string) is included in `[tool.poetry]`, then migrates it from `[tool.poetry]` to `[project]`. If multiple `readme` values are defined (as a table) in `[tool.poetry]`, `readme` is added to the `dynamic` field list.
- Adds unit tests for each migration scenario
- Updates README to include new `Poetry v2.0.0+ Changes`
