### PR TITLE
[#240] Remove unnecessary abstract methods from AbstractPythonPackageAndDependencyManagerSetup

### DIFF
--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/AbstractPythonPackageAndDependencyManagerSetup.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/AbstractPythonPackageAndDependencyManagerSetup.java
@@ -107,7 +107,7 @@ public abstract class AbstractPythonPackageAndDependencyManagerSetup {
     protected abstract List<String> validatePackageAndDependencyManagerInstallationAndVersion(ValidationTrackingStatus validationTracker, List<String> missingRequiredToolMsgs) 
         throws MojoExecutionException;
 
-    protected abstract void finalizePythonPackageAndDependencyManagerConfiguration() throws MojoExecutionException;
+    protected void finalizePythonPackageAndDependencyManagerConfiguration() throws MojoExecutionException {};
 
     private void validatePythonVersion(String currentPythonVersion) throws MojoExecutionException {
         if (StringUtils.isNotBlank(currentPythonVersion)) {
@@ -124,8 +124,10 @@ public abstract class AbstractPythonPackageAndDependencyManagerSetup {
 
     protected abstract String pythonSourceMessage() throws MojoExecutionException;
 
-    public abstract void registerRepositoryToSupportAuthenticatedDependencyResolution(String repoId, String username, String password) throws MojoExecutionException;
+    protected void registerRepositoryToSupportAuthenticatedDependencyResolution(String repoId, String username, String password) throws MojoExecutionException {};
 
-    public abstract String findCurrentVirtualEnvironmentFullPath() throws MojoExecutionException;
+    protected String findCurrentVirtualEnvironmentFullPath() throws MojoExecutionException {
+        return StringUtils.EMPTY;
+    };
 
 }

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/UvSetup.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/UvSetup.java
@@ -3,8 +3,6 @@ package org.technologybrewery.habushu;
 import com.vdurmont.semver4j.Semver;
 import com.vdurmont.semver4j.Semver.SemverType;
 
-import org.apache.commons.lang3.NotImplementedException;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
@@ -83,21 +81,10 @@ public class UvSetup extends AbstractPythonPackageAndDependencyManagerSetup {
         }
         return missingRequiredToolMsgs;
     }
-    
-    @Override
-    protected void finalizePythonPackageAndDependencyManagerConfiguration() {
-        // No additional configuration is necessary for uv at this time.
-    }
 
     @Override
     protected String pythonSourceMessage() {
         return "(managed by uv)";
-    }
-
-    @Override
-    public void registerRepositoryToSupportAuthenticatedDependencyResolution(String repoId, String username, String password) throws MojoExecutionException, NotImplementedException {
-        // TODO: move this method out of the abstract methods as this is specific to Poetry.
-        // uv does not support a config command to store username and password credentials. Users must enter this information via the publish command.
     }
 
     /**
@@ -109,11 +96,4 @@ public class UvSetup extends AbstractPythonPackageAndDependencyManagerSetup {
     protected UvCommandHelper createUvCommandHelper() {
         return new UvCommandHelper(baseDir);
     }
-
-    @Override
-    public String findCurrentVirtualEnvironmentFullPath() throws MojoExecutionException {
-        // TODO: move this method out of the abstract method as this method is specfic to Poetry
-        return StringUtils.EMPTY;
-    }
-
 }


### PR DESCRIPTION
Removed unused abstract methods from `UvSetup` by removing the abstract modifier from these methods in the abstract class, `AbstractPythonPackageAndDependencyManagerSetup`.