### PR TITLE
[#225] Update python version defaulting

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,8 @@ mvn clean install -Dhabushu.pythonVersion=3.10.4
 
 #### pythonVersion ####
 
-The desired version of Python to use.
+The desired version of Python to use. If `pythonVersion` is not set then Habushu will use the `defaultPythonStrategy`
+configuration to determine where to get the default Python version.
 
 Default: `3.12.9`
 
@@ -323,6 +324,14 @@ Default: `3.12.9`
 This configuration applies only to Poetry projects. If true, Habushu will delegate to `pyenv` for managing and (if needed) installing the specified version of Python. If false, Habushu will look for the desired version of Python on the `PATH`. If Python is not found or if the version does not match the configured `pythonVersion`, the build will fail.
 
 Default: `true`
+
+#### defaultPythonStrategy ####
+
+When `pythonVersion` is not explicitly specified, this strategy helps decide where to get the default version. If set to 
+`PYTHONVERSION`, then Habushu will use the existing project's Python version. If set to `POM`, then Habushu will use 
+the default value for `pythonVerion`
+
+Default: `PYTHONVERSION`
 
 #### behaveOptions ####
 
@@ -883,6 +892,8 @@ configuration options.
 - [Adding Habushu to an Existing Poetry Project](./examples/add-habushu-to-new-or-existing-poetry-project/README.md) - Adding Habushu to an existing Poetry project
 - [Managed Dependencies](./examples/habushu-managed-dependencies/README.md) - supports common definition of dependency 
   versions across Maven modules
+- [Default Python Strategy](./examples/habushu-default-python-strategy/README.md) - Handles the strategy for setting 
+  the default python version if no version is explicitly set in `pythonVersion`
 
 ### Maven Reactor Integration ###
 Optionally, Habushu supports partial builds via the Maven Reactor. This allows functionality such as `-rf` (resume from)

--- a/examples/habushu-default-python-strategy/README.md
+++ b/examples/habushu-default-python-strategy/README.md
@@ -1,0 +1,21 @@
+[[Return to Main Documentation]](../../README.md)
+
+#### defaultPythonStrategy ####
+
+If the python version is not explicitly set in the `pythonVersion` configuration then `defaultPythonStrategy` is
+used to determine where to get the default Python version. The default value for `defaultPythonStrategy` is
+`PYTHONVERSION` which tells Habushu to use the existing projects Python version if it can be found. If the 
+configuration is set to `POM` then Habushu will override the projects version with `pythonVersion` default value.
+```xml
+<plugin>
+    <groupId>org.technologybrewery.habushu</groupId>
+    <artifactId>habushu-maven-plugin</artifactId>
+    ...
+    <configuration>
+        <!-- This will prevent the Habushu default python version from overriding the existing projects version -->
+        <defaultPythonStrategy>PYTHONVERSION</defaultPythonStrategy>
+        <!-- This will tell Habushu to overriding the existing projects with the default Python version -->
+        <!--<defaultPythonStrategy>POM</defaultPythonStrategy>-->
+    </configuration>
+</plugin>
+```

--- a/examples/habushu-default-python-strategy/poetry.toml
+++ b/examples/habushu-default-python-strategy/poetry.toml
@@ -1,0 +1,4 @@
+[virtualenvs]
+prefer-active-python = true
+in-project = true
+use-poetry-python = false

--- a/examples/habushu-default-python-strategy/pom.xml
+++ b/examples/habushu-default-python-strategy/pom.xml
@@ -1,0 +1,57 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.technologybrewery.habushu</groupId>
+        <artifactId>examples</artifactId>
+        <version>3.0.0-SNAPSHOT</version>
+    </parent>
+
+    <name>habushu::Examples::Default Python Strategy</name>
+    <description>Example of how to use the habushu config defaultPythonStrategy determine python versions</description>
+
+    <artifactId>habushu-default-python-strategy</artifactId>
+    <packaging>habushu</packaging>
+
+    <properties>
+        <!-- Override the python version defined in the parent project. Not necessary if the project doesn't extend
+        the org.technologybrewery.parent -->
+        <version.python.default/>
+    </properties>
+
+    <dependencies>
+        <!-- NB: workaround to trigger build cache invalidation when a new SNAPSHOT is available-->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>habushu-maven-plugin</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <directory>dist</directory>
+        <plugins>
+            <plugin>
+                <groupId>org.technologybrewery.habushu</groupId>
+                <artifactId>habushu-maven-plugin</artifactId>
+                <configuration>
+                    <!-- This will prevent the Habushu default python version from overriding the existing projects
+                    version -->
+                    <defaultPythonStrategy>PYTHONVERSION</defaultPythonStrategy>
+                    <!-- This will tell Habushu to overriding the existing projects with the default Python version -->
+                    <!--<defaultPythonStrategy>POM</defaultPythonStrategy>-->
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>net.masterthought</groupId>
+                <artifactId>maven-cucumber-reporting</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/examples/habushu-default-python-strategy/pyproject.toml
+++ b/examples/habushu-default-python-strategy/pyproject.toml
@@ -1,29 +1,22 @@
 [tool.poetry]
-name = "habushu_poetry_package"
+name = "habushu_default_python_strategy"
 version = "3.0.0.dev"
-description = "Example of how to use the habushu-maven-plugin"
-authors = ["Eric Konieczny <ekoniec1@gmail.com>"]
+description = "Example of how to use the habushu default python strategy configuration"
+authors = ["Ryan Ashcraft <ryan.ashcraft@codifyiq.com>"]
 license = "MIT License"
 
 [tool.poetry.dependencies]
 python = "^3.11"
-krausening = ">=20"
-cryptography = ">=44.0.1"
-uvicorn = ">=0.19.0"
-
 
 [tool.poetry.group.dev.dependencies]
 behave = ">=1.2.6"
 pylint = ">=3.1.0"
-black = ">=24.3.0"
-python-dotenv = "^0.20.0"
-grpcio-tools = "^1.48.0"
+black = ">=24.0.0"
 kappa-maki = ">=1.0.0"
 
 [build-system]
 requires = ["poetry-core>=1.6.0"]
 build-backend = "poetry.core.masonry.api"
-
 
 # Added by habushu-maven-plugin at 2024-05-06T17:43:13.504546 to use https://test.pypi.org/simple/ as source PyPi repository for installing dependencies
 [[tool.poetry.source]]

--- a/examples/habushu-default-python-strategy/src/habushu_default_python_strategy/helloworld.py
+++ b/examples/habushu-default-python-strategy/src/habushu_default_python_strategy/helloworld.py
@@ -1,0 +1,4 @@
+import string
+import random
+
+print("I'm alive!")

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -67,6 +67,7 @@
                 <module>habushu-poetry-package</module>
                 <module>habushu-poetry-package-consumer</module>
                 <module>habushu-managed-dependencies</module>
+                <module>habushu-default-python-strategy</module>
             </modules>
         </profile>
         <profile>

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/AbstractPythonPackageAndDependencyManagerSetup.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/AbstractPythonPackageAndDependencyManagerSetup.java
@@ -5,6 +5,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.technologybrewery.habushu.util.DefaultPythonStrategy;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -25,6 +26,18 @@ public abstract class AbstractPythonPackageAndDependencyManagerSetup {
      * The desired version of Python to use.
      */
     protected String pythonVersion;
+
+    /**
+     * If the python version configuration was set
+     */
+    protected boolean isPythonVersionConfigurationSet;
+
+    /**
+     * Determines the default Python version strategy.
+     * PYTHONVERSION to use the existing projects python version.
+     * POM to use the pythonVersion configuration default value.
+     */
+    protected String defaultPythonStrategy;
 
     /**
      * Base directory from which to write Python package and dependency management files.
@@ -63,9 +76,12 @@ public abstract class AbstractPythonPackageAndDependencyManagerSetup {
      * @param rewriteLocalPathDepsInArchives see member variable for details
      * @param log                            the logger to use for output
      */
-    protected AbstractPythonPackageAndDependencyManagerSetup(String pythonVersion, File baseDir,
-                                                     boolean rewriteLocalPathDepsInArchives, Log log) {
+    protected AbstractPythonPackageAndDependencyManagerSetup(String pythonVersion, boolean isPythonVersionConfigurationSet,
+                                                             String defaultPythonStrategy, File baseDir,
+                                                             boolean rewriteLocalPathDepsInArchives, Log log) {
         this.pythonVersion = pythonVersion;
+        this.isPythonVersionConfigurationSet = isPythonVersionConfigurationSet;
+        this.defaultPythonStrategy = defaultPythonStrategy;
         this.baseDir = baseDir;
         this.rewriteLocalPathDepsInArchives = rewriteLocalPathDepsInArchives;
         this.log = log;
@@ -107,7 +123,9 @@ public abstract class AbstractPythonPackageAndDependencyManagerSetup {
     protected abstract List<String> validatePackageAndDependencyManagerInstallationAndVersion(ValidationTrackingStatus validationTracker, List<String> missingRequiredToolMsgs) 
         throws MojoExecutionException;
 
-    protected void finalizePythonPackageAndDependencyManagerConfiguration() throws MojoExecutionException {};
+    protected void finalizePythonPackageAndDependencyManagerConfiguration() {
+
+    }
 
     private void validatePythonVersion(String currentPythonVersion) throws MojoExecutionException {
         if (StringUtils.isNotBlank(currentPythonVersion)) {
@@ -124,10 +142,19 @@ public abstract class AbstractPythonPackageAndDependencyManagerSetup {
 
     protected abstract String pythonSourceMessage() throws MojoExecutionException;
 
-    protected void registerRepositoryToSupportAuthenticatedDependencyResolution(String repoId, String username, String password) throws MojoExecutionException {};
+    protected void registerRepositoryToSupportAuthenticatedDependencyResolution(String repoId, String username, String password) {
 
-    protected String findCurrentVirtualEnvironmentFullPath() throws MojoExecutionException {
+    }
+
+    protected String findCurrentVirtualEnvironmentFullPath() {
         return StringUtils.EMPTY;
-    };
+    }
+
+    protected boolean useCurrentPythonVersion(String currentPythonVersion) {
+        // If the python version configuration is not set and the desired default python version is the existing
+        // projects version, set the desired python version to the current projects version
+        return !isPythonVersionConfigurationSet && (defaultPythonStrategy.equals(DefaultPythonStrategy.PYTHONVERSION.name()) &&
+                StringUtils.isNotEmpty(currentPythonVersion));
+    }
 
 }

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/CleanHabushuMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/CleanHabushuMojo.java
@@ -10,6 +10,7 @@ import org.apache.maven.plugins.clean.CleanMojo;
 import org.apache.maven.plugins.clean.Fileset;
 import org.technologybrewery.habushu.exec.PoetryCommandHelper;
 import org.technologybrewery.habushu.util.HabushuUtil;
+import org.technologybrewery.habushu.util.PackageManager;
 
 import java.io.File;
 import java.lang.reflect.Field;
@@ -60,8 +61,14 @@ public class CleanHabushuMojo extends CleanMojo {
     /**
      * The desired version of Python to use.
      */
-    @Parameter(defaultValue = HabushuUtil.PYTHON_DEFAULT_VERSION_REQUIREMENT, property = "habushu.pythonVersion")
+    @Parameter(property = "habushu.pythonVersion")
     protected String pythonVersion;
+
+    /**
+     * The default python version strategy.
+     */
+    @Parameter(defaultValue = "PYTHONVERSION", property = "habushu.defaultPythonStrategy")
+    protected String defaultPythonStrategy;
 
     /**
      * Should Habushu use pyenv with Poetry to manage the utilized version of Python?
@@ -123,9 +130,15 @@ public class CleanHabushuMojo extends CleanMojo {
         boolean removeVenvManually = false;
 
         // TODO: This code is specific to Poetry. uv does not provide a command to remove a virtual environment like Poetry.
-        HabushuUtil.PackageManager packageManager = HabushuUtil.checkPythonPackageManager(new File(workingDirectory, "pyproject.toml"));
+        PackageManager packageManager = HabushuUtil.checkPythonPackageManager(new File(workingDirectory, "pyproject.toml"));
+        boolean isPythonVersionConfigurationSet = true;
+        if (StringUtils.isEmpty(pythonVersion)) {
+            isPythonVersionConfigurationSet = false;
+            pythonVersion = HabushuUtil.PYTHON_DEFAULT_VERSION_REQUIREMENT;
+        }
         AbstractPythonPackageAndDependencyManagerSetup configureTools = HabushuUtil.getPythonPackageAndDependencyManager(packageManager,
-        pythonVersion, workingDirectory, rewriteLocalPathDepsInArchives, getLog(), usePyenv, patchInstallScript); 
+        pythonVersion, isPythonVersionConfigurationSet, defaultPythonStrategy, workingDirectory, rewriteLocalPathDepsInArchives,
+                getLog(), usePyenv, patchInstallScript);
 
         String virtualEnvFullPath = configureTools.findCurrentVirtualEnvironmentFullPath();
 

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/InitializeHabushuMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/InitializeHabushuMojo.java
@@ -5,6 +5,7 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.technologybrewery.habushu.util.HabushuUtil;
+import org.technologybrewery.habushu.util.PackageManager;
 
 /**
  * Ensures that the current project is a valid Poetry or uv project and initializes
@@ -19,7 +20,7 @@ public class InitializeHabushuMojo extends AbstractHabushuMojo {
     public void doExecute() throws MojoExecutionException, MojoFailureException {
         String pomVersion = project.getVersion();
         String expectedPythonPackageVersion = getPythonPackageVersion(pomVersion, false, null);
-        if (HabushuUtil.checkPythonPackageManager(getPyProjectTomlFile()) == HabushuUtil.PackageManager.POETRY){
+        if (HabushuUtil.checkPythonPackageManager(getPyProjectTomlFile()) == PackageManager.POETRY){
             InitializeHabushuPoetry initializeHabushuPoetry = new InitializeHabushuPoetry(getPythonProjectBaseDir(), getLog(), overridePackageVersion, expectedPythonPackageVersion );
             initializeHabushuPoetry.doExecute();
         } else {

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/InstallDependenciesMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/InstallDependenciesMojo.java
@@ -6,6 +6,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.technologybrewery.habushu.util.HabushuUtil;
+import org.technologybrewery.habushu.util.PackageManager;
 
 import java.util.List;
 
@@ -100,7 +101,7 @@ public class InstallDependenciesMojo extends AbstractHabushuMojo {
                 withoutGroups, forceSync, managedDependencies, updateManagedDependenciesWhenFound, failOnManagedDependenciesMismatches, useInProjectVirtualEnvironment, pypiRepoId, pypiRepoUrl,
                 useDevRepository, devRepositoryId, devRepositoryUrl, overridePackageVersion);
 
-        if (HabushuUtil.checkPythonPackageManager(getPyProjectTomlFile()) == HabushuUtil.PackageManager.POETRY){
+        if (HabushuUtil.checkPythonPackageManager(getPyProjectTomlFile()) == PackageManager.POETRY) {
             InstallDependenciesPoetry installDependenciesPoetry = new InstallDependenciesPoetry(getPythonProjectBaseDir(), getLog(), installDependenciesConfigurations);
             installDependenciesPoetry.doExecute();
         } else {
@@ -108,7 +109,4 @@ public class InstallDependenciesMojo extends AbstractHabushuMojo {
             installDependenciesUv.doExecute();
         }
     }
-
-
-
 }

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/PyenvAndPoetrySetup.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/PyenvAndPoetrySetup.java
@@ -47,8 +47,10 @@ public class PyenvAndPoetrySetup extends AbstractPythonPackageAndDependencyManag
      * @param usePyenv              whether we are using pyenv to instance and activate python versions
      * @param patchInstallScript    patch install script path
      */
-    public PyenvAndPoetrySetup(String pythonVersion, File baseDir, boolean rewriteLocalPathDepsInArchives, Log log, boolean usePyenv, File patchInstallScript) {
-        super(pythonVersion, baseDir, rewriteLocalPathDepsInArchives, log); 
+    public PyenvAndPoetrySetup(String pythonVersion, boolean isPythonVersionConfigurationSet, String defaultPythonStrategy,
+                               File baseDir, boolean rewriteLocalPathDepsInArchives, Log log, boolean usePyenv,
+                               File patchInstallScript) {
+        super(pythonVersion, isPythonVersionConfigurationSet, defaultPythonStrategy, baseDir, rewriteLocalPathDepsInArchives, log);
         this.usePyenv = usePyenv;
         this.patchInstallScript = patchInstallScript;
     }
@@ -71,7 +73,10 @@ public class PyenvAndPoetrySetup extends AbstractPythonPackageAndDependencyManag
         try {
             currentPythonVersion = pyenvHelper.getCurrentPythonVersion();
         } catch (Exception e) {
-            log.info("Failed to find current python version. Attempting to install it now.");
+            log.info("Failed to find current python version.");
+        }
+        if (useCurrentPythonVersion(currentPythonVersion)) {
+            pythonVersion = currentPythonVersion;
         }
         if (!pythonVersion.equals(currentPythonVersion)) {
             pyenvHelper.updatePythonVersion(pythonVersion, patchInstallScript);
@@ -154,6 +159,19 @@ public class PyenvAndPoetrySetup extends AbstractPythonPackageAndDependencyManag
         }
     }
 
+    @Override
+    public String findCurrentVirtualEnvironmentFullPath() {
+        String virtualEnvFullPath = null;
+        try {
+            PoetryCommandHelper poetryHelper = new PoetryCommandHelper(baseDir);
+            virtualEnvFullPath = poetryHelper.execute(Arrays.asList("env", "list", "--full-path"));
+        } catch (RuntimeException e) {
+            log.debug("Could not retrieve Poetry-managed virtual environment path - it likely does not exist", e);
+        }
+
+        return virtualEnvFullPath;
+    }
+
     /**
      * Creates a {@link PyenvCommandHelper} that may be used to invoke Pyenv
      * commands from the project's working directory.
@@ -172,6 +190,9 @@ public class PyenvAndPoetrySetup extends AbstractPythonPackageAndDependencyManag
         } catch (MojoExecutionException mojoExecutionException) {
             throw new MojoExecutionException(
                     "Expected Python version " + pythonVersion + ", but it was not installed");
+        }
+        if (useCurrentPythonVersion(currentPythonVersion)) {
+            pythonVersion = currentPythonVersion;
         }
         return currentPythonVersion;
     }
@@ -237,22 +258,8 @@ public class PyenvAndPoetrySetup extends AbstractPythonPackageAndDependencyManag
      *
      * @return command helper
      */
-    protected PoetryCommandHelper createPoetryCommandHelper() {
+    private PoetryCommandHelper createPoetryCommandHelper() {
         return new PoetryCommandHelper(baseDir);
     }
-
-    @Override
-    public String findCurrentVirtualEnvironmentFullPath() {
-        String virtualEnvFullPath = null;
-        try {
-            PoetryCommandHelper poetryHelper = new PoetryCommandHelper(baseDir);
-            virtualEnvFullPath = poetryHelper.execute(Arrays.asList("env", "list", "--full-path"));
-        } catch (RuntimeException e) {
-            log.debug("Could not retrieve Poetry-managed virtual environment path - it likely does not exist", e);
-        }
-        
-        return virtualEnvFullPath;
-    }
-
 
 }

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/PythonPackageAndDependencyManagerFactory.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/PythonPackageAndDependencyManagerFactory.java
@@ -4,19 +4,28 @@ import java.io.File;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
-import org.technologybrewery.habushu.util.HabushuUtil;
+import org.technologybrewery.habushu.util.PackageManager;
 
 public class PythonPackageAndDependencyManagerFactory {
+
+    private PythonPackageAndDependencyManagerFactory() {
+        throw new IllegalStateException("Utility class");
+    }
+
     public static AbstractPythonPackageAndDependencyManagerSetup createPythonPackageAndDependencyManagerSetup(
-        String pythonVersion, File baseDir, boolean rewriteLocalPathDepsInArchives, Log log, HabushuUtil.PackageManager pythonPackageAndDependencyManager,
+        String pythonVersion, boolean isPythonVersionConfigurationSet, String defaultPythonStrategy, File baseDir,
+        boolean rewriteLocalPathDepsInArchives, Log log, PackageManager pythonPackageAndDependencyManager,
         Boolean usePyenv, File patchInstallScript) throws MojoExecutionException {
-        if (pythonPackageAndDependencyManager == HabushuUtil.PackageManager.POETRY){
+
+        if (pythonPackageAndDependencyManager == PackageManager.POETRY){
             if ((usePyenv == null) || (patchInstallScript == null)) {
                 throw new MojoExecutionException("PyenvAndPoetrySetup requires usePyenv and patchInstallScript.");
             }
-            return new PyenvAndPoetrySetup(pythonVersion, baseDir, rewriteLocalPathDepsInArchives, log, usePyenv, patchInstallScript);
+            return new PyenvAndPoetrySetup(pythonVersion, isPythonVersionConfigurationSet, defaultPythonStrategy, baseDir,
+                    rewriteLocalPathDepsInArchives, log, usePyenv, patchInstallScript);
         } else {
-            return new UvSetup(pythonVersion, baseDir, rewriteLocalPathDepsInArchives, log);
+            return new UvSetup(pythonVersion, isPythonVersionConfigurationSet, defaultPythonStrategy, baseDir,
+                    rewriteLocalPathDepsInArchives, log);
         }
     }
 }

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/UvSetup.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/UvSetup.java
@@ -3,6 +3,7 @@ package org.technologybrewery.habushu;
 import com.vdurmont.semver4j.Semver;
 import com.vdurmont.semver4j.Semver.SemverType;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
@@ -21,17 +22,17 @@ import java.util.List;
  */
 public class UvSetup extends AbstractPythonPackageAndDependencyManagerSetup {
    
-    public UvSetup(String pythonVersion, File baseDir, boolean rewriteLocalPathDepsInArchives, Log log) throws MojoExecutionException {
-        super(pythonVersion, baseDir, rewriteLocalPathDepsInArchives, log); 
+    public UvSetup(String pythonVersion, boolean isPythonVersionConfigurationSet, String defaultPythonStrategy, File baseDir,
+                   boolean rewriteLocalPathDepsInArchives, Log log) {
+        super(pythonVersion, isPythonVersionConfigurationSet, defaultPythonStrategy, baseDir, rewriteLocalPathDepsInArchives, log);
     }
 
     /**
-     * Checks if the .python-version file exists. If it exists, it returns the python version listed therein.
-     * If it doesn't exist, then it checks if a .venv exists. If it exists, it returns the python version being
-     * used in the environemnt. If the .venv doesn't exist, then a .python-version file is created with habushu's default
-     * pythonVersion.
+     * Gets the current python version from either the .python-version file or the .venv. It compares this with the
+     * desired python version and if it is different it will pin project to that version. Desired python version is
+     * determined by the habushu config pythonVersion. If that is not set then it will default to the current
+     * projects python version or the default habushu version depending on the config defaultPythonStrategy
      *
-     * @param missingRequiredToolMsgs
      * @return the current Python version
      * @throws MojoExecutionException
      */
@@ -40,11 +41,17 @@ public class UvSetup extends AbstractPythonPackageAndDependencyManagerSetup {
             throws MojoExecutionException {
         UvCommandHelper uvHelper = createUvCommandHelper();
         String currentPythonVersion = uvHelper.getCurrentPythonVersion();
-            if (currentPythonVersion.isEmpty()) {
-                logger.info("The Python version is not currently set for the project. Setting the version...");
-                uvHelper.updatePythonVersion(pythonVersion);
-                currentPythonVersion = uvHelper.getCurrentPythonVersion();
-            }
+
+        if (useCurrentPythonVersion(currentPythonVersion)) {
+            pythonVersion = currentPythonVersion;
+        }
+
+        // If the current python version does not match the desired version, update it to the desired version
+        if (!StringUtils.equals(currentPythonVersion, pythonVersion)) {
+            logger.info("The Python version is not currently set to the desired version. Setting the version...");
+            uvHelper.updatePythonVersion(pythonVersion);
+            currentPythonVersion = uvHelper.getCurrentPythonVersion();
+        }
         return currentPythonVersion;
     }
 

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/ValidatePythonPackageAndDependencyManagerMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/ValidatePythonPackageAndDependencyManagerMojo.java
@@ -9,6 +9,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.plexus.util.StringUtils;
 import org.technologybrewery.habushu.util.HabushuUtil;
+import org.technologybrewery.habushu.util.PackageManager;
 import org.technologybrewery.habushu.util.PoetryUtil;
 import org.technologybrewery.habushu.util.UvUtil;
 
@@ -34,8 +35,14 @@ public class ValidatePythonPackageAndDependencyManagerMojo extends AbstractHabus
     /**
      * The desired version of Python to use.
      */
-    @Parameter(defaultValue = HabushuUtil.PYTHON_DEFAULT_VERSION_REQUIREMENT, property = "habushu.pythonVersion")
+    @Parameter(property = "habushu.pythonVersion")
     protected String pythonVersion;
+
+    /**
+     * The default python version strategy.
+     */
+    @Parameter(defaultValue = "PYTHONVERSION", property = "habushu.defaultPythonStrategy")
+    protected String defaultPythonStrategy;
 
     /**
      * Should Habushu use pyenv to manage the utilized version of Python?
@@ -53,10 +60,19 @@ public class ValidatePythonPackageAndDependencyManagerMojo extends AbstractHabus
 
     @Override
     public void doExecute() throws MojoExecutionException, MojoFailureException {
+        PackageManager packageManager = HabushuUtil.checkPythonPackageManager(getPyProjectTomlFile());
+        boolean isPythonVersionConfigurationSet = true;
 
-        HabushuUtil.PackageManager packageManager = HabushuUtil.checkPythonPackageManager(getPyProjectTomlFile());
-        AbstractPythonPackageAndDependencyManagerSetup configureTools = HabushuUtil.getPythonPackageAndDependencyManager(packageManager,
-        pythonVersion, getPythonProjectBaseDir(), rewriteLocalPathDepsInArchives, getLog(), usePyenv, patchInstallScript);
+        // If pythonVersion was not given then update isPythonVersionConfigurationSet and set it to the default
+        if (StringUtils.isEmpty(pythonVersion)) {
+            isPythonVersionConfigurationSet = false;
+            pythonVersion = HabushuUtil.PYTHON_DEFAULT_VERSION_REQUIREMENT;
+        }
+
+        AbstractPythonPackageAndDependencyManagerSetup configureTools =
+                HabushuUtil.getPythonPackageAndDependencyManager(packageManager, pythonVersion, isPythonVersionConfigurationSet,
+                        defaultPythonStrategy, getPythonProjectBaseDir(), rewriteLocalPathDepsInArchives, getLog(),
+                        usePyenv, patchInstallScript);
 
         configureTools.execute();
 
@@ -64,7 +80,7 @@ public class ValidatePythonPackageAndDependencyManagerMojo extends AbstractHabus
         configurePrivateDevPyPiRepositoryCredentials(configureTools);
     }
 
-    private void configurePrivateDevPyPiRepositoryCredentials(AbstractPythonPackageAndDependencyManagerSetup configureTools) throws MojoExecutionException {
+    private void configurePrivateDevPyPiRepositoryCredentials(AbstractPythonPackageAndDependencyManagerSetup configureTools) {
         if (useDevRepository) {
             if (!TEST_PYPI_REPOSITORY_URL.equals(devRepositoryUrl)){
                 String pypiDevRepoIdUsername = findUsernameForServer(devRepositoryId);
@@ -77,7 +93,7 @@ public class ValidatePythonPackageAndDependencyManagerMojo extends AbstractHabus
         }
     }
 
-    private void configurePrivatePyPiRepositoryCredentials(AbstractPythonPackageAndDependencyManagerSetup configureTools) throws MojoExecutionException {
+    private void configurePrivatePyPiRepositoryCredentials(AbstractPythonPackageAndDependencyManagerSetup configureTools) {
         if (StringUtils.isNotEmpty(pypiRepoUrl) && !"https://pypi.org".equals(pypiRepoUrl)) {
             String pypiRepoIdUsername = findUsernameForServer(pypiRepoId);
             String pypiRepoIdPassword = findPasswordForServer(pypiRepoId);

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/exec/UvCommandHelper.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/exec/UvCommandHelper.java
@@ -27,15 +27,13 @@ public class UvCommandHelper extends AbstractCommandHelper {
     private static final String UV_COMMAND = "uv";
     private static final Logger logger = LoggerFactory.getLogger(UvCommandHelper.class);
 
-    private static final String extractUvVersionRegex = "^(?:uv\\s)\\b((\\d+.?)(\\d+.?){1,2})\\b";
+    private static final String EXTRACT_UV_VERSION_REGEX = "^(?:uv\\s)\\b((\\d+.?)(\\d+.?){1,2})\\b";
 
-    private static final Pattern uvVersionPattern = Pattern.compile(extractUvVersionRegex);
+    private static final Pattern UV_VERSION_PATTERN = Pattern.compile(EXTRACT_UV_VERSION_REGEX);
 
-    private static final String extractPythonVersionRegex = "^(?:[Pp]ython\\s)\\b((\\d+.?)(\\d+.?){1,2})\\b";
+    private static final String EXTRACT_PYTHON_VERSION_REGEX = "^(?:[Pp]ython\\s)\\b((\\d+.?)(\\d+.?){1,2})\\b";
 
-    private static final Pattern pythonVersionPattern = Pattern.compile(extractPythonVersionRegex);
-
-    protected File workingDirectory;
+    private static final Pattern pythonVersionPattern = Pattern.compile(EXTRACT_PYTHON_VERSION_REGEX);
 
     protected String pythonVersionFile; 
 
@@ -58,19 +56,19 @@ public class UvCommandHelper extends AbstractCommandHelper {
      */
     public Pair<Boolean, String> getIsUvInstalledAndVersion() {
         try {
-            ProcessExecutor executor = createPackageManagerExecutor(Arrays.asList("--version"));
+            ProcessExecutor executor = createPackageManagerExecutor(List.of("--version"));
             String versionResult = executor.executeAndGetResult(logger);
 
             // Extracts version number from output, given the following format "uv 0.5.20 (1c17662b3 2025-01-15)"
-            String version = getMatchedPattern(uvVersionPattern, versionResult);
+            String version = getMatchedPattern(UV_VERSION_PATTERN, versionResult);
             if (!version.isEmpty()){
-                return new ImmutablePair<Boolean, String>(true, version); 
+                return new ImmutablePair<>(true, version);
             } else {
                 throw new HabushuException("uv version pattern not found.");
             }
             
         } catch (Throwable e) {
-            return new ImmutablePair<Boolean, String>(false, null);
+            return new ImmutablePair<>(false, null);
         }
     }
 
@@ -83,16 +81,14 @@ public class UvCommandHelper extends AbstractCommandHelper {
      */
     public String getCurrentPythonVersion() throws MojoExecutionException {
         String currentPythonVersion = pythonVersionFileContents();
-        if (!currentPythonVersion.isEmpty()) {
-            return currentPythonVersion;
-        } else {
+        if (currentPythonVersion.isEmpty()) {
             currentPythonVersion = pythonVersionFromVirtualEnvironment();
-            if (!currentPythonVersion.isEmpty()){
+            if (!currentPythonVersion.isEmpty()) {
                 logger.info("A .python-version does not currently exist for this package. Creating it now with the Python version being used in the current virutal environment (in .venv).");
                 updatePythonVersion(currentPythonVersion);
             }
-            return currentPythonVersion;
         }
+        return currentPythonVersion;
     }
 
     /**
@@ -100,7 +96,7 @@ public class UvCommandHelper extends AbstractCommandHelper {
      *
      * @return
      */
-    public void updatePythonVersion(String targetVersion) throws MojoExecutionException {
+    public void updatePythonVersion(String targetVersion) {
         List<String> pythonPinCommand = createPythonPinCommand(targetVersion);
         execute(pythonPinCommand);
     }
@@ -189,7 +185,7 @@ public class UvCommandHelper extends AbstractCommandHelper {
 
     private String pythonVersionFileContents() throws MojoExecutionException {
         String pythonVersion = StringUtils.EMPTY;
-        if (checkFileExistance(pythonVersionFile)) {
+        if (Boolean.TRUE.equals(checkFileExistance(pythonVersionFile))) {
             try {
                 Path pythonVersionFilePath = Paths.get(pythonVersionFile);
                 pythonVersion = Files.readString(pythonVersionFilePath, StandardCharsets.UTF_8).strip();

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/util/DefaultPythonStrategy.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/util/DefaultPythonStrategy.java
@@ -1,0 +1,6 @@
+package org.technologybrewery.habushu.util;
+
+public enum DefaultPythonStrategy {
+    PYTHONVERSION,
+    POM
+}

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/util/HabushuUtil.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/util/HabushuUtil.java
@@ -25,11 +25,6 @@ import java.io.InputStreamReader;
  */
 public final class HabushuUtil {
 
-    public enum PackageManager {
-        POETRY,
-        UV
-    }
-
     private static final Logger logger = LoggerFactory.getLogger(HabushuUtil.class);
 
     /**
@@ -197,7 +192,9 @@ public final class HabushuUtil {
     }
 
     public static AbstractPythonPackageAndDependencyManagerSetup getPythonPackageAndDependencyManager(
-            PackageManager pythonPackageAndDependencyManager, String pythonVersion, File baseDir, boolean rewriteLocalPathDepsInArchives, Log log, Boolean usePyenv, File patchInstallScript) throws MojoExecutionException {
+            PackageManager pythonPackageAndDependencyManager, String pythonVersion, boolean isPythonVersionConfigurationSet,
+            String defaultPythonStrategy, File baseDir, boolean rewriteLocalPathDepsInArchives, Log log,
+            Boolean usePyenv, File patchInstallScript) throws MojoExecutionException {
         // Set the poetry-based parameters to null
         if (pythonPackageAndDependencyManager == PackageManager.UV) {
             usePyenv = null;
@@ -205,7 +202,8 @@ public final class HabushuUtil {
         }
 
         return PythonPackageAndDependencyManagerFactory.createPythonPackageAndDependencyManagerSetup(
-                pythonVersion, baseDir, rewriteLocalPathDepsInArchives, log, pythonPackageAndDependencyManager, usePyenv, patchInstallScript);
+                pythonVersion, isPythonVersionConfigurationSet, defaultPythonStrategy, baseDir, rewriteLocalPathDepsInArchives, log,
+                pythonPackageAndDependencyManager, usePyenv, patchInstallScript);
     }
 
     /**

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/util/PackageManager.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/util/PackageManager.java
@@ -1,0 +1,6 @@
+package org.technologybrewery.habushu.util;
+
+public enum PackageManager {
+    POETRY,
+    UV
+}


### PR DESCRIPTION
Updating python version overrides for an existing python project. If the pythonVersion config is set then it will still be the desired version but if it is not then we will delegate the python version to the existing projects version. This can be updated by the new config defaultPythonStrategy.
Created example project for defaultPythonStrategy
#225 