### PR TITLE
[#260] Update BehaveBddTestMojo to handle different package managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,7 +729,8 @@ Default: `${project.basedir}/src`
 
 #### testDirectory ####
 
-Folder in which Python test files are located - should align with Poetry's project structure conventions. Developers will typically **not** modify this property but is made available for customization to support unanticipated scenarios.
+Folder in which Python test files are located - should align with standard project structure conventions. 
+Developers will typically **not** modify this property but is made available for customization to support unanticipated scenarios.
 
 Default: `${project.basedir}/tests`
 

--- a/examples/habushu-uv-package/.gitignore
+++ b/examples/habushu-uv-package/.gitignore
@@ -1,4 +1,4 @@
 # Ignore everything in generated package with the exception of __init__.py - protobuf bindings are generated
 # into this package as a part of the automated build and should *not* be version-controlled
-src/habushu_poetry_package_uv/generated/__init__.py
-!src/habushu_poetry_package_uv/generated/__init__.py
+src/habushu_uv_package/generated/__init__.py
+!src/habushu_uv_package/generated/__init__.py

--- a/examples/habushu-uv-package/pom.xml
+++ b/examples/habushu-uv-package/pom.xml
@@ -48,23 +48,6 @@
             <plugin>
                 <groupId>org.technologybrewery.habushu</groupId>
                 <artifactId>habushu-maven-plugin</artifactId>
-                <!-- Utilize the run-command-in-virtual-env goal to demonstrate how
-                    commands/scripts may be executed via "poetry run" and bound to the build
-                    lifecycle phases -->
-                <executions>
-                    <execution>
-                        <configuration>
-                            <runCommandArgs>python -m grpc_tools.protoc -I=src
-                                --python_out=src/habushu_poetry_package/generated src/person.proto
-                            </runCommandArgs>
-                        </configuration>
-                        <id>generate-protobuf-bindings</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>run-command-in-virtual-env</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>net.masterthought</groupId>

--- a/examples/habushu-uv-package/src/habushu_uv_package/helloworld.py
+++ b/examples/habushu-uv-package/src/habushu_uv_package/helloworld.py
@@ -1,6 +1,6 @@
 import string
 import random
-from habushu_poetry_package_uv.reusable_module.worker import SubWorker
+from habushu_uv_package.reusable_module.worker import SubWorker
 
 print("I'm alive!")
 

--- a/examples/habushu-uv-package/src/habushu_uv_package/reusable_module/worker.py
+++ b/examples/habushu-uv-package/src/habushu_uv_package/reusable_module/worker.py
@@ -1,5 +1,5 @@
 # a simple module
-from habushu_poetry_package_uv.util.useful import i_do_something_useful
+from habushu_uv_package.util.useful import i_do_something_useful
 
 
 class SubWorker:

--- a/examples/habushu-uv-package/tests/features/steps/reference_src.py
+++ b/examples/habushu-uv-package/tests/features/steps/reference_src.py
@@ -1,7 +1,6 @@
 from behave import when, then  # pylint: disable=no-name-in-module
-from habushu_poetry_package_uv.reusable_module.worker import SubWorker
-from habushu_poetry_package_uv.helloworld import generate_random_string
-from habushu_poetry_package_uv.generated import person_pb2
+from habushu_uv_package.reusable_module.worker import SubWorker
+from habushu_uv_package.helloworld import generate_random_string
 import logging
 
 
@@ -9,9 +8,6 @@ import logging
 def step_impl(context):
     logging.info("Referencing a src file...")
     context.random = generate_random_string(5)
-    person = person_pb2.Person()  # pylint: disable=no-member
-    person.email = "habushu@gmail.com"
-    context.person = person
 
 
 @when("I reference a src file that has references to other src files")
@@ -23,7 +19,6 @@ def step_impl(context):
 @then("the build can successfully resolve the imports")
 def step_impl(context):
     assert len(context.random) == 5
-    assert context.person.email == "habushu@gmail.com"
 
 
 @then("the build can successfully resolve the nested imports")

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/AbstractBehaveBddTest.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/AbstractBehaveBddTest.java
@@ -1,0 +1,107 @@
+package org.technologybrewery.habushu;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.logging.Log;
+import org.technologybrewery.habushu.exec.AbstractCommandHelper;
+
+public abstract class AbstractBehaveBddTest {
+
+    protected static final String BEHAVE_PACKAGE = "behave";
+    protected static final String BEHAVE_CUCUMBER_FORMATTER = "kappa-maki";
+    protected static final String KAPPA_FORMAT = "kappa_maki.kappa_maki_formatter:PrettyCucumberJSONFormatter";
+    protected Log log;
+    protected BehaveBddTestMojo behaveBddTestMojo;
+    protected AbstractCommandHelper commandHelper;
+
+    protected AbstractBehaveBddTest(Log log, BehaveBddTestMojo behaveBddTestMojo, AbstractCommandHelper commandHelper) {
+        this.log = log;
+        this.behaveBddTestMojo = behaveBddTestMojo;
+        this.commandHelper = commandHelper;
+    }
+
+    public void doExecute() throws MojoExecutionException, MojoFailureException {
+
+        if (this.behaveBddTestMojo.isSkipTests()) {
+            this.log.warn("Tests are skipped (-DskipTests=true)");
+            return;
+        }
+
+        File behaveDirectory = new File(this.behaveBddTestMojo.getTestDirectory(), "features");
+        String canonicalPathForFile = this.behaveBddTestMojo.getCanonicalPathForFile(behaveDirectory);
+        if (hasTests(behaveDirectory)) {
+            checkAndInstallBehave();
+
+            // The package managers Habushu currently supports run this behave command in the exact same way
+            List<String> executeBehaveTestArgs = new ArrayList<>(Arrays.asList("run", BEHAVE_PACKAGE,
+                    canonicalPathForFile));
+
+            appendBehaveOptions(executeBehaveTestArgs);
+
+            this.log.info(String.format("Executing behave tests in %s...", canonicalPathForFile));
+            this.log.info("-------------------------------------------------------");
+            this.log.info("T E S T S");
+            this.log.info("-------------------------------------------------------");
+            this.commandHelper.executeAndLogOutput(executeBehaveTestArgs,
+                    this.behaveBddTestMojo.getBehaveTestEnvironmentVariables());
+        } else {
+            this.log.warn(String.format("No tests found in %s", canonicalPathForFile));
+        }
+    }
+
+    protected void checkAndInstallBehave() {
+        if (!this.commandHelper.isDependencyInstalled(BEHAVE_PACKAGE)) {
+            this.log.info(String.format("%s dependency not specified in pyproject.toml - installing now...",
+                    BEHAVE_PACKAGE));
+            this.commandHelper.installDevelopmentDependency(BEHAVE_PACKAGE);
+        }
+    }
+
+    protected boolean hasTests(File behaveDirectory) throws MojoExecutionException {
+        boolean hasTests = false;
+        if (behaveDirectory.exists()) {
+            try (Stream<Path> path = Files.list(behaveDirectory.toPath())) {
+                hasTests = path.findAny().isPresent();
+            } catch (IOException e) {
+                throw new MojoExecutionException("Could not load behave features directory", e);
+            }
+        }
+        return hasTests;
+    }
+
+    protected void appendBehaveOptions(List<String> executeBehaveTestArgs) {
+        if (this.behaveBddTestMojo.isOutputCucumberStyleTestReports()) {
+            this.commandHelper.installDevelopmentDependency(BEHAVE_CUCUMBER_FORMATTER);
+            executeBehaveTestArgs.add("--format=" + KAPPA_FORMAT);
+            executeBehaveTestArgs.add("--outfile=target/cucumber-reports/cucumber.json");
+            executeBehaveTestArgs.add("--format=progress2");
+        }
+
+        if (this.behaveBddTestMojo.isOmitSkippedTests()) {
+            executeBehaveTestArgs.add("--no-skipped");
+        }
+
+        if (this.behaveBddTestMojo.isDisableOutputCapture()) {
+            executeBehaveTestArgs.add("--no-capture");
+            executeBehaveTestArgs.add("--no-capture-stderr");
+            executeBehaveTestArgs.add("--no-logcapture");
+        }
+
+        if (StringUtils.isNotEmpty(this.behaveBddTestMojo.getBehaveOptions())) {
+            executeBehaveTestArgs.addAll(Arrays.asList(StringUtils.split(this.behaveBddTestMojo.getBehaveOptions())));
+        } else if (this.behaveBddTestMojo.isBehaveExcludeManualTag()) {
+            executeBehaveTestArgs.add("--tags=-manual");
+        }
+    }
+
+}

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/AbstractHabushuMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/AbstractHabushuMojo.java
@@ -210,6 +210,42 @@ public abstract class AbstractHabushuMojo extends AbstractMojo {
     @Parameter(defaultValue = "false", property = "habushu.rewriteLocalPathDepsInArchives")
     protected boolean rewriteLocalPathDepsInArchives;
 
+    public Settings getSettings() {
+        return settings;
+    }
+
+    public boolean isDecryptPassword() {
+        return decryptPassword;
+    }
+
+    public String getPackaging() {
+        return packaging;
+    }
+
+    public File getSourceDirectory() {
+        return sourceDirectory;
+    }
+
+    public File getTestDirectory() {
+        return testDirectory;
+    }
+
+    public boolean isUseDevRepository() {
+        return useDevRepository;
+    }
+
+    public boolean isOverridePackageVersion() {
+        return overridePackageVersion;
+    }
+
+    public MavenProject getProject() {
+        return project;
+    }
+
+    public boolean isRewriteLocalPathDepsInArchives() {
+        return rewriteLocalPathDepsInArchives;
+    }
+
     /**
      * Find the username for a given server in Maven's user settings.
      *
@@ -328,7 +364,7 @@ public abstract class AbstractHabushuMojo extends AbstractMojo {
     }
 
     /**
-     * Creates a {@link PoetryCommandHelper} that may be used to invoke uv
+     * Creates a {@link UvCommandHelper} that may be used to invoke uv
      * commands from the project's working directory.
      *
      * @return

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/BehaveBddTestMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/BehaveBddTestMojo.java
@@ -1,21 +1,15 @@
 package org.technologybrewery.habushu;
 
-import org.apache.commons.lang3.StringUtils;
+import java.util.Map;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
-import org.technologybrewery.habushu.exec.PoetryCommandHelper;
-
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import org.technologybrewery.habushu.util.HabushuUtil;
+import org.technologybrewery.habushu.util.PackageManager;
 
 /**
  * Leverages the behave package to execute BDD scenarios that are defined in the
@@ -30,20 +24,17 @@ import java.util.Map;
         threadSafe = true)
 public class BehaveBddTestMojo extends AbstractHabushuMojo {
 
-    protected static final String BEHAVE_PACKAGE = "behave";
-    protected static final String BEHAVE_CUCUMBER_FORMATTER = "kappa-maki";
-
     /**
      * Options that should be passed to the behave command. <b>NOTE:</b> If this
      * value is provided, then {@link #behaveExcludeManualTag} is ignored.
      */
-    @Parameter(property = "habushu.behaveOptions", required = false)
+    @Parameter(property = "habushu.behaveOptions")
     protected String behaveOptions;
 
     /**
      * By default, format Behave test results in a JSON compatible with Cucumber Reports plugin
      */
-    @Parameter(property = "habushu.outputCucumberStyleTestReports", required = false, defaultValue = "true")
+    @Parameter(property = "habushu.outputCucumberStyleTestReports", defaultValue = "true")
     protected boolean outputCucumberStyleTestReports;
 
     /**
@@ -51,7 +42,7 @@ public class BehaveBddTestMojo extends AbstractHabushuMojo {
      * other test steps themselves pass. To match Cucumber's default logic, this setting will prevent capturing skipped
      * tests if there are no failures.
      */
-    @Parameter(property = "habushu.omitSkippedTests", required = false, defaultValue = "true")
+    @Parameter(property = "habushu.omitSkippedTests", defaultValue = "true")
     protected boolean omitSkippedTests;
 
     /**
@@ -82,71 +73,44 @@ public class BehaveBddTestMojo extends AbstractHabushuMojo {
     @Parameter(property = "habushu.behaveTestEnvironmentVariables")
     protected Map<String, String> behaveTestEnvironmentVariables = null;
 
+    public String getBehaveOptions() {
+        return behaveOptions;
+    }
+
+    public boolean isOutputCucumberStyleTestReports() {
+        return outputCucumberStyleTestReports;
+    }
+
+    public boolean isOmitSkippedTests() {
+        return omitSkippedTests;
+    }
+
+    public boolean isBehaveExcludeManualTag() {
+        return behaveExcludeManualTag;
+    }
+
+    public boolean isSkipTests() {
+        return skipTests;
+    }
+
+    public boolean isDisableOutputCapture() {
+        return disableOutputCapture;
+    }
+
+    public Map<String, String> getBehaveTestEnvironmentVariables() {
+        return behaveTestEnvironmentVariables;
+    }
 
     @Override
     public void doExecute() throws MojoExecutionException, MojoFailureException {
-
-        if (skipTests) {
-            getLog().warn("Tests are skipped (-DskipTests=true)");
-            return;
-        }
-
-        File behaveDirectory = new File(testDirectory, "features");
-
-        boolean hasTests;
-        try {
-            hasTests = behaveDirectory.exists() && Files.list(behaveDirectory.toPath()).findAny().isPresent();
-        } catch (IOException e) {
-            throw new MojoExecutionException("Could not load behave features directory", e);
-        }
-
-        if (hasTests) {
-            PoetryCommandHelper poetryHelper = createPoetryCommandHelper();
-
-            if (!poetryHelper.isDependencyInstalled(BEHAVE_PACKAGE)) {
-                getLog().info(String.format("%s dependency not specified in pyproject.toml - installing now...",
-                        BEHAVE_PACKAGE));
-                poetryHelper.installDevelopmentDependency(BEHAVE_PACKAGE);
-            }
-
-            List<String> executeBehaveTestArgs = new ArrayList<>();
-            executeBehaveTestArgs
-                    .addAll(Arrays.asList("run", BEHAVE_PACKAGE, getCanonicalPathForFile(behaveDirectory)));
-
-            if (outputCucumberStyleTestReports) {
-                poetryHelper.installDevelopmentDependency(BEHAVE_CUCUMBER_FORMATTER);
-                executeBehaveTestArgs.add("--format=kappa_maki.kappa_maki_formatter:PrettyCucumberJSONFormatter");
-                executeBehaveTestArgs.add("--outfile=target/cucumber-reports/cucumber.json");
-                executeBehaveTestArgs.add("--format=progress2");
-            }
-
-            if (omitSkippedTests) {
-                executeBehaveTestArgs.add("--no-skipped");
-            }
-
-            if (disableOutputCapture) {
-                executeBehaveTestArgs.add("--no-capture");
-                executeBehaveTestArgs.add("--no-capture-stderr");
-                executeBehaveTestArgs.add("--no-logcapture");
-            }
-
-            if (StringUtils.isNotEmpty(behaveOptions)) {
-                executeBehaveTestArgs.addAll(Arrays.asList(StringUtils.split(behaveOptions)));
-            } else {
-                if (behaveExcludeManualTag) {
-                    executeBehaveTestArgs.add("--tags=-manual");
-                }
-            }
-
-            getLog().info(String.format("Executing behave tests in %s...", getCanonicalPathForFile(behaveDirectory)));
-            getLog().info("-------------------------------------------------------");
-            getLog().info("T E S T S");
-            getLog().info("-------------------------------------------------------");
-            poetryHelper.executeAndLogOutput(executeBehaveTestArgs, behaveTestEnvironmentVariables);
+        if (HabushuUtil.checkPythonPackageManager(getPyProjectTomlFile()) == PackageManager.POETRY) {
+            BehaveBddTestPoetry behaveBddTestPoetry = new BehaveBddTestPoetry(getLog(), this,
+                    createPoetryCommandHelper());
+            behaveBddTestPoetry.doExecute();
         } else {
-            getLog().warn(String.format("No tests found in %s", getCanonicalPathForFile(behaveDirectory)));
+            BehaveBddTestUv behaveBddTestUv = new BehaveBddTestUv(getLog(), this,
+                    createUvCommandHelper());
+            behaveBddTestUv.doExecute();
         }
-
     }
-
 }

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/BehaveBddTestPoetry.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/BehaveBddTestPoetry.java
@@ -1,0 +1,11 @@
+package org.technologybrewery.habushu;
+
+import org.apache.maven.plugin.logging.Log;
+import org.technologybrewery.habushu.exec.PoetryCommandHelper;
+
+public class BehaveBddTestPoetry extends AbstractBehaveBddTest {
+
+    public BehaveBddTestPoetry(Log log, BehaveBddTestMojo behaveBddTestMojo, PoetryCommandHelper poetryCommandHelper) {
+        super(log, behaveBddTestMojo, poetryCommandHelper);
+    }
+}

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/BehaveBddTestUv.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/BehaveBddTestUv.java
@@ -1,0 +1,11 @@
+package org.technologybrewery.habushu;
+
+import org.apache.maven.plugin.logging.Log;
+import org.technologybrewery.habushu.exec.UvCommandHelper;
+
+public class BehaveBddTestUv extends AbstractBehaveBddTest {
+
+    public BehaveBddTestUv(Log log, BehaveBddTestMojo behaveBddTestMojo, UvCommandHelper uvCommandHelper) {
+        super(log, behaveBddTestMojo, uvCommandHelper);
+    }
+}

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/FormatPythonMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/FormatPythonMojo.java
@@ -83,15 +83,10 @@ public class FormatPythonMojo extends AbstractHabushuMojo {
     }
 
     protected void downloadFormatterIfNotPresent(AbstractCommandHelper helper) throws HabushuException {
-        try {
-            if (!helper.isDependencyInstalled(FORMATTER_PACKAGE)) {
-                getLog().info(
-                        String.format("%s dependency not specified in pyproject.toml - installing now...", FORMATTER_PACKAGE));
-                helper.installDevelopmentDependency(FORMATTER_PACKAGE);
-            }
-        } catch (MojoExecutionException e) {
-            getLog().error(String.format("Error installing formatter package: %s", FORMATTER_PACKAGE));
-            throw new HabushuException(e);
+        if (!helper.isDependencyInstalled(FORMATTER_PACKAGE)) {
+            getLog().info(
+                    String.format("%s dependency not specified in pyproject.toml - installing now...", FORMATTER_PACKAGE));
+            helper.installDevelopmentDependency(FORMATTER_PACKAGE);
         }
     }
 

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/exec/AbstractCommandHelper.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/exec/AbstractCommandHelper.java
@@ -152,6 +152,23 @@ public abstract class AbstractCommandHelper {
         }
     }
 
+    /**
+     * Returns whether the specified dependency package is installed within this
+     * project's virtual environment (and pyproject.toml).
+     *
+     * @param packageName the package name to check
+     * @return whether the package is installed
+     */
+    public abstract boolean isDependencyInstalled(String packageName);
+
+    /**
+     * Installs the specified package as a development dependency to this
+     * project's virtual environment and pyproject.toml specification.
+     *
+     * @param packageName the dependency to install
+     */
+    public abstract void installDevelopmentDependency(String packageName);
+
     protected ProcessExecutor createPackageManagerExecutor(List<String> arguments) {
         List<String> fullCommandArgs = new ArrayList<>();
         fullCommandArgs.add(packageManagerCommand);
@@ -165,9 +182,4 @@ public abstract class AbstractCommandHelper {
         fullCommandArgs.addAll(arguments);
         return new ProcessExecutor(workingDirectory, fullCommandArgs, Platform.guess(), environmentVariables);
     }
-
-    public abstract boolean isDependencyInstalled(String formatter);
-
-    public abstract void installDevelopmentDependency(String formatter) throws MojoExecutionException;
-
 }

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/exec/PoetryCommandHelper.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/exec/PoetryCommandHelper.java
@@ -56,11 +56,7 @@ public class PoetryCommandHelper extends AbstractCommandHelper {
     }
 
     /**
-     * Returns whether the specified dependency package is installed within this
-     * Poetry project's virtual environment (and pyproject.toml).
-     *
-     * @param packageName the dependency to check
-     * @return whether Dependency is Installed
+     * {@inheritDoc}
      */
     @Override
     public boolean isDependencyInstalled(String packageName) {
@@ -73,11 +69,9 @@ public class PoetryCommandHelper extends AbstractCommandHelper {
     }
 
     /**
-     * Installs the specified package as a development dependency to this Poetry
-     * project's virtual environment and pyproject.toml specification.
-     *
-     * @param packageName the dependency to install
+     * {@inheritDoc}
      */
+    @Override
     public void installDevelopmentDependency(String packageName) {
         execute(Arrays.asList("add", packageName, "--group", "dev"));
     }

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/exec/UvCommandHelper.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/exec/UvCommandHelper.java
@@ -102,11 +102,7 @@ public class UvCommandHelper extends AbstractCommandHelper {
     }
 
     /**
-     * Returns whether the specified dependency package is installed within this
-     * uv project's virtual environment (and pyproject.toml).
-     *
-     * @param packageName
-     * @return
+     * {@inheritDoc}
      */
     @Override
     public boolean isDependencyInstalled(String packageName) {
@@ -116,17 +112,13 @@ public class UvCommandHelper extends AbstractCommandHelper {
             return false;
         }
         return true;
-
     }
 
     /**
-     * Installs the specified package as a development dependency to this uv
-     * project's virtual environment and pyproject.toml specification.
-     *
-     * @param packageName
+     * {@inheritDoc}
      */
     @Override
-    public void installDevelopmentDependency(String packageName) throws MojoExecutionException {
+    public void installDevelopmentDependency(String packageName) {
         execute(Arrays.asList("add", packageName, "--group", "dev"));
     }
 


### PR DESCRIPTION
Created an abstract behave test class for both uv and poetry to extend. The Mojo just determines which to use. Currently their executions are the same so the main execute functionality is in the parent abstract
Signed-off-by: woods-cpointe <cwoods@cpointe-inc.com>