### PR TITLE
[#268] Update formatter tests to use updated toml files and pull down missing formatters

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -37,15 +37,7 @@ jobs:
               if: steps.cached-poetry.outputs.cache-hit != 'true'
               uses: snok/install-poetry@v1
 
-            - name: Load cached uv installation
-              id: cached-uv
-              uses: actions/cache@v4
-              with:
-                path: ~/.local
-                key: uv-0  # increment to reset cache
-
             - name: Install uv
-              if: steps.cached-uv.outputs.cache-hit != 'true'
               uses: astral-sh/setup-uv@v5
               with:
                 # Install a specific version of uv.
@@ -59,7 +51,10 @@ jobs:
                   cache: maven
 
             - name: Build habushu-maven-plugin
-              run: mvn -B install -Pbootstrap --file pom.xml 
+              run: mvn -B install -Pbootstrap --file pom.xml
 
-            - name: Test habushu-maven-plugin
+            - name: Test habushu-maven-plugin (Poetry)
               run: mvn -B install --file pom.xml -Dhabushu.usePyenv=false
+
+            - name: Test habushu-maven-plugin (uv)
+              run: mvn -B install -Puv --file pom.xml -Dhabushu.usePyenv=false

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/exec/PoetryCommandHelper.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/exec/PoetryCommandHelper.java
@@ -61,11 +61,11 @@ public class PoetryCommandHelper extends AbstractCommandHelper {
     @Override
     public boolean isDependencyInstalled(String packageName) {
         try {
-            execute(Arrays.asList("show", packageName));
+            String result = execute(Arrays.asList("show", packageName)).trim();
+            return !result.isEmpty();
         } catch (Throwable e) {
             return false;
         }
-        return true;
     }
 
     /**

--- a/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/FormatPythonMojoTestWrapper.java
+++ b/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/FormatPythonMojoTestWrapper.java
@@ -6,6 +6,7 @@ import org.technologybrewery.habushu.exec.UvCommandHelper;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.List;
 
 public class FormatPythonMojoTestWrapper extends FormatPythonMojo {
 
@@ -33,8 +34,16 @@ public class FormatPythonMojoTestWrapper extends FormatPythonMojo {
 
     @Override
     protected void downloadFormatterIfNotPresent(AbstractCommandHelper helper) {
+
+        // These are pre-requesite steps to showing installed dependencies
+        if (helper instanceof PoetryCommandHelper) {
+            helper.execute(Arrays.asList("sync", "--no-root"));
+        } else { // UvCommandHelper
+            helper.execute(List.of("sync"));
+        }
+
         if (!helper.isDependencyInstalled(FORMATTER_PACKAGE)) {
-            getLog().info( String.format("%s dependency not specified in pyproject.toml - installing now...", FORMATTER_PACKAGE));
+            super.downloadFormatterIfNotPresent(helper);
             packageInstallAttempted = true;
         } else {
             getLog().info(String.format("Successfully found %s dependency", FORMATTER_PACKAGE));
@@ -44,5 +53,10 @@ public class FormatPythonMojoTestWrapper extends FormatPythonMojo {
     @Override
     protected File getPyProjectTomlFile() {
         return new File("target/test-classes/test-formatter/workdir/pyproject.toml");
+    }
+
+    @Override
+    protected File getPythonProjectBaseDir() {
+        return new File("target/test-classes/test-formatter/workdir");
     }
 }

--- a/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/FormatterSteps.java
+++ b/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/FormatterSteps.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class FormatterSteps {
@@ -85,6 +86,7 @@ public class FormatterSteps {
 
     @Then("the validation should automatically format the file")
     public void theValidationShouldAutomaticallyFormatTheFile() throws IOException {
+        assertFalse("Expected pyproject.toml to already include the formatter", mojo.wasPackageInstallAttempted());
         String expected = Files.readString(expectedFormattedFile.toPath());
         String real = Files.readString(targetPyFile.toPath());
         assertEquals("Expected file contents for formatter does not match", expected, real);
@@ -113,7 +115,7 @@ public class FormatterSteps {
     }
 
     private void initializeTestDirectory(File baseToml) throws IOException {
-        mojo.setSourceDirectory(targetPyFile.getParentFile());
+        mojo.setSourceDirectory(target);
         mojo.setTestDirectory(new File("this/directory/does/not/exist"));
         FileUtils.copyFile(baseToml, targetTomlFile);
     }

--- a/habushu-maven-plugin/src/test/resources/specifications/python-formatting.feature
+++ b/habushu-maven-plugin/src/test/resources/specifications/python-formatting.feature
@@ -1,4 +1,4 @@
-@manual @formatter
+@formatter
 Feature: Python Formatting
 
   Scenario Outline: Habushu formats Python files if formatting is incorrect

--- a/habushu-maven-plugin/src/test/resources/test-formatter/formatter-missing-test-pyproject.toml
+++ b/habushu-maven-plugin/src/test/resources/test-formatter/formatter-missing-test-pyproject.toml
@@ -1,24 +1,14 @@
-[tool.poetry]
+[project]
 name = "habushu_poetry_package"
 version = "2.4.0.dev"
 description = "Example of how to use the habushu-maven-plugin"
-authors = ["Eric Konieczny <ekoniec1@gmail.com>"]
+authors = [{name = "Eric Konieczny", email = "ekoniec1@gmail.com"}]
 license = "MIT License"
-
-[tool.poetry.dependencies]
-python = "^3.9"
-krausening = "16"
-cryptography = "^39.0.1"
-
-[tool.poetry.group.dev.dependencies]
-behave = "^1.2.6"
-grpcio-tools = "^1.48.0"
-python-dotenv = "^0.20.0"
-uvicorn = {version = "^0.16.0", extras = ["standard"]}
-behave-cucumber-formatter = ">=1.0.1"
+requires-python = ">=3.11"
+dynamic = ["version"]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]

--- a/habushu-maven-plugin/src/test/resources/test-formatter/formatter-no-config-test-pyproject.toml
+++ b/habushu-maven-plugin/src/test/resources/test-formatter/formatter-no-config-test-pyproject.toml
@@ -1,23 +1,15 @@
-[tool.poetry]
+[project]
 name = "habushu_poetry_package"
 version = "2.4.0.dev"
 description = "Example of how to use the habushu-maven-plugin"
-authors = ["Eric Konieczny <ekoniec1@gmail.com>"]
+authors = [{name = "Eric Konieczny", email = "ekoniec1@gmail.com"}]
 license = "MIT License"
-
-[tool.poetry.dependencies]
-python = "^3.9"
-krausening = "16"
-cryptography = "^39.0.1"
+requires-python = ">=3.11"
+dynamic = ["version"]
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.9.9"
-behave = "^1.2.6"
-grpcio-tools = "^1.48.0"
-python-dotenv = "^0.20.0"
-uvicorn = {version = "^0.16.0", extras = ["standard"]}
-behave-cucumber-formatter = ">=1.0.1"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/habushu-maven-plugin/src/test/resources/test-formatter/formatter-test-pyproject.toml
+++ b/habushu-maven-plugin/src/test/resources/test-formatter/formatter-test-pyproject.toml
@@ -1,25 +1,17 @@
-[tool.poetry]
+[project]
 name = "habushu_poetry_package"
 version = "2.4.0.dev"
 description = "Example of how to use the habushu-maven-plugin"
-authors = ["Eric Konieczny <ekoniec1@gmail.com>"]
+authors = [{name = "Eric Konieczny", email = "ekoniec1@gmail.com"}]
 license = "MIT License"
-
-[tool.poetry.dependencies]
-python = "^3.9"
-krausening = "16"
-cryptography = "^39.0.1"
+requires-python = ">=3.11"
+dynamic = ["version"]
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.9.9"
-behave = "^1.2.6"
-grpcio-tools = "^1.48.0"
-python-dotenv = "^0.20.0"
-uvicorn = {version = "^0.16.0", extras = ["standard"]}
-behave-cucumber-formatter = ">=1.0.1"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]

--- a/habushu-maven-plugin/src/test/resources/test-formatter/formatter-uv-missing-test-pyproject.toml
+++ b/habushu-maven-plugin/src/test/resources/test-formatter/formatter-uv-missing-test-pyproject.toml
@@ -6,22 +6,9 @@ authors = [
 ]
 license = {text = "MIT License"}
 requires-python = "<4.0,>=3.9"
-dependencies = [
-    "krausening==16",
-    "cryptography<40.0.0,>=39.0.1",
-]
 name = "habushu_uv_package"
 version = "2.4.0.dev"
 description = "Example of how to use the habushu-maven-plugin"
-
-[dependency-groups]
-dev = [
-    "behave<2.0.0,>=1.2.6",
-    "grpcio-tools<2.0.0,>=1.48.0",
-    "python-dotenv<1.0.0,>=0.20.0",
-    "uvicorn[standard]<1.0.0,>=0.16.0",
-    "behave-cucumber-formatter>=1.0.1",
-]
 
 [tool.ruff]
 line-length = 120

--- a/habushu-maven-plugin/src/test/resources/test-formatter/formatter-uv-no-config-test-pyproject.toml
+++ b/habushu-maven-plugin/src/test/resources/test-formatter/formatter-uv-no-config-test-pyproject.toml
@@ -6,10 +6,6 @@ authors = [
 ]
 license = {text = "MIT License"}
 requires-python = "<4.0,>=3.9"
-dependencies = [
-    "krausening==16",
-    "cryptography<40.0.0,>=39.0.1",
-]
 name = "habushu_uv_package"
 version = "2.4.0.dev"
 description = "Example of how to use the habushu-maven-plugin"
@@ -17,11 +13,6 @@ description = "Example of how to use the habushu-maven-plugin"
 [dependency-groups]
 dev = [
     "ruff>=0.9.9",
-    "behave<2.0.0,>=1.2.6",
-    "grpcio-tools<2.0.0,>=1.48.0",
-    "python-dotenv<1.0.0,>=0.20.0",
-    "uvicorn[standard]<1.0.0,>=0.16.0",
-    "behave-cucumber-formatter>=1.0.1",
 ]
 
 [tool.ruff]

--- a/habushu-maven-plugin/src/test/resources/test-formatter/formatter-uv-test-pyproject.toml
+++ b/habushu-maven-plugin/src/test/resources/test-formatter/formatter-uv-test-pyproject.toml
@@ -6,10 +6,6 @@ authors = [
 ]
 license = {text = "MIT License"}
 requires-python = "<4.0,>=3.9"
-dependencies = [
-    "krausening==16",
-    "cryptography<40.0.0,>=39.0.1",
-]
 name = "habushu_uv_package"
 version = "2.4.0.dev"
 description = "Example of how to use the habushu-maven-plugin"
@@ -17,11 +13,6 @@ description = "Example of how to use the habushu-maven-plugin"
 [dependency-groups]
 dev = [
     "ruff>=0.9.9",
-    "behave<2.0.0,>=1.2.6",
-    "grpcio-tools<2.0.0,>=1.48.0",
-    "python-dotenv<1.0.0,>=0.20.0",
-    "uvicorn[standard]<1.0.0,>=0.16.0",
-    "behave-cucumber-formatter>=1.0.1",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
#268

* Update pyproject.toml examples to be up to date with `examples/` toml formatting
* Fix bug causing dependency manager to not run install
* Add test wrapper override for project root