### PR TITLE
#266 "Ruff format forces users to not use the ^ in the requires-python section of the pyproject.toml"

### DIFF
--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryToProjectRequiresPythonMigration.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryToProjectRequiresPythonMigration.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 public class PoetryToProjectRequiresPythonMigration extends AbstractPoetryMigration{
     private static final Logger logger = LoggerFactory.getLogger(PoetryToProjectRequiresPythonMigration.class);
     private String pythonDependencyVersion;
+    private boolean updateFaultyFormat = false;
 
     @Override
     protected boolean shouldExecuteOnFile(File file) {
@@ -36,6 +37,17 @@ public class PoetryToProjectRequiresPythonMigration extends AbstractPoetryMigrat
                     if (!projectGroupEntry.contains(TomlUtils.REQUIRES_PYTHON)) {
                         shouldExecute = true;
                         logger.info("Adding to [{}] group entry! ({})", TomlUtils.PROJECT, TomlUtils.REQUIRES_PYTHON);
+                    } else {
+                        String requiresPythonSemver = projectGroupEntry.get(TomlUtils.REQUIRES_PYTHON);
+                        if (requiresPythonSemver.contains(TomlUtils.CARROT)) {
+                            updateFaultyFormat = true;
+                            shouldExecute = true;
+                            pythonDependencyVersion = TomlUtils.refactorCarrotIntoGreaterThanLessThan(requiresPythonSemver);
+                            logger.info("Reformatting ({}) in group entry [{}] to use >=,< notation!",
+                                    TomlUtils.REQUIRES_PYTHON,
+                                    TomlUtils.PROJECT
+                            );
+                        }
                     }
 
                     // grab original python dependency version from [tool.poetry.dependencies]
@@ -44,6 +56,9 @@ public class PoetryToProjectRequiresPythonMigration extends AbstractPoetryMigrat
                         Config poetryDependenciesGroupEntry = poetryDependenciesGroup.get();
                         if (poetryDependenciesGroupEntry.contains(TomlUtils.PYTHON)) {
                             pythonDependencyVersion = poetryDependenciesGroupEntry.get(TomlUtils.PYTHON);
+                            if (pythonDependencyVersion.contains(TomlUtils.CARROT)) {
+                                pythonDependencyVersion = TomlUtils.refactorCarrotIntoGreaterThanLessThan(pythonDependencyVersion);
+                            }
                         }
                     }
                 }
@@ -59,6 +74,7 @@ public class PoetryToProjectRequiresPythonMigration extends AbstractPoetryMigrat
         boolean inPoetryDependenciesSection = false;
         boolean injectedRequiresPython = false;
         boolean injectAfterNextEmptyLine = false;
+        boolean correctedRequiresPython = false;
         String requiresPythonLine = TomlUtils.REQUIRES_PYTHON + " " + TomlUtils.EQUALS + " " + TomlUtils.DOUBLE_QUOTE + pythonDependencyVersion + TomlUtils.DOUBLE_QUOTE;
         StringBuilder fileContent = new StringBuilder();
 
@@ -93,8 +109,16 @@ public class PoetryToProjectRequiresPythonMigration extends AbstractPoetryMigrat
                         if (key.equalsIgnoreCase(TomlUtils.PYTHON)) {
                             addLine = false;
                         }
-                    } else if (inProjectSection && !injectedRequiresPython){
-                        injectAfterNextEmptyLine = true;
+                    } else if (inProjectSection) {
+                        if (updateFaultyFormat && trimmedLine.contains(TomlUtils.REQUIRES_PYTHON) && !correctedRequiresPython) {
+                            // Update the faulty formatted "requires-python" line to use greater-than or less-than notation
+                            addLine = false;
+                            fileContent.append(requiresPythonLine).append("\n");
+                            correctedRequiresPython = true;
+                        } else if (!updateFaultyFormat && !injectedRequiresPython) {
+                            // Otherwise inject the missing "requires-python" line
+                            injectAfterNextEmptyLine = true;
+                        }
                     }
                 }
                 if (isEmptyLine && injectAfterNextEmptyLine ) {

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/util/TomlUtils.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/util/TomlUtils.java
@@ -42,7 +42,13 @@ public final class TomlUtils {
     public static final String REQUIRES = "requires";
     public static final String POETRY_CORE ="poetry-core";
     public static final String DOT = ".";
+    public static final String DOT_REGEX = "\\.";
     public static final String PYPROJECT_TOML = "pyproject.toml";
+    public static final String CARROT = "^";
+    public static final String CARROT_REGEX = "\\^";
+    public static final String GREATER_THAN_OR_EQUAL_TO = ">=";
+    public static final String COMMA = ",";
+    public static final String LESS_THAN = "<";
 
 
     protected TomlUtils() {
@@ -158,6 +164,29 @@ public final class TomlUtils {
             lastDigitIndex =  matcher.end();
         }
         return lastDigitIndex;
+    }
+
+    public static String refactorCarrotIntoGreaterThanLessThan(String semver) {
+        String[] carrotSplit = semver.split(CARROT_REGEX);
+        String semverNoComparator = carrotSplit[1];
+
+        Integer nextMajorSemver;
+
+        if (semverNoComparator.contains(DOT)) { // e.g. ^3.11 turns into >=3.11,<4
+            String[] semverSplit = semverNoComparator.split(DOT_REGEX);
+            nextMajorSemver = Integer.parseInt(semverSplit[0]) + 1;
+        } else { // e.g. ^3 turns into >=3,<4
+            nextMajorSemver = Integer.parseInt(semverNoComparator) + 1;
+        }
+
+        StringBuilder newSemver = new StringBuilder()
+                .append(GREATER_THAN_OR_EQUAL_TO)
+                .append(semverNoComparator)
+                .append(COMMA)
+                .append(LESS_THAN)
+                .append(nextMajorSemver);
+
+        return newSemver.toString();
     }
 
 }

--- a/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryToProjectRequiresPythonMigrationSteps.java
+++ b/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryToProjectRequiresPythonMigrationSteps.java
@@ -13,8 +13,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PoetryToProjectRequiresPythonMigrationSteps extends AbstractPoetryMigrationSteps {
-    private PoetryCommandHelperTestWrapper poetryHelper;
-    private boolean mockIsPoetryVersionAtLeast2;
+    protected PoetryCommandHelperTestWrapper poetryHelper;
+    protected boolean mockIsPoetryVersionAtLeast2;
+
 
     @Given("Poetry version is at least \"2.0.0\"")
     public void poetry_version_is_at_least_2_0_0(){
@@ -32,7 +33,25 @@ public class PoetryToProjectRequiresPythonMigrationSteps extends AbstractPoetryM
 
     @Given("an existing pyproject.toml file with no requires-python entry in the project group")
     public void an_existing_pyproject_toml_file_with_no_requires_python_entry_in_the_project_group() {
-        pyProjectToml = new File(testTomlFileDirectory, "with-no-requires-python-in-project.toml");
+        pyProjectToml = new File(testTomlFileDirectory, "with-no-python-requirement-tag-in-project.toml");
+        assertKeyExists(TomlUtils.PROJECT, TomlUtils.REQUIRES_PYTHON, false);
+    }
+
+    @Given("an existing pyproject.toml file with a requires-python entry in the project group")
+    public void an_existing_pyproject_toml_file_with_a_requires_python_entry_in_project_group() {
+        pyProjectToml = new File(testTomlFileDirectory, "with-python-requirement-tag-in-project.toml");
+        assertKeyExists(TomlUtils.PROJECT, TomlUtils.REQUIRES_PYTHON, true);
+    }
+
+    @Given("an existing pyproject.toml file with a badly formatted requires-python entry in the project group")
+    public void an_existing_pyproject_toml_file_with_a_badly_formatted_requires_python_entry_in_project_group() {
+        pyProjectToml = new File(testTomlFileDirectory, "with-python-requirement-tag-in-project-badly-formatted.toml");
+        assertKeyExists(TomlUtils.PROJECT, TomlUtils.REQUIRES_PYTHON, true);
+    }
+
+    @Given("an existing pyproject.toml file with no requires-python")
+    public void an_existing_pyproject_toml_file_without_a_requires_python_entry_in_project_group() {
+        pyProjectToml = new File(testTomlFileDirectory, "no-poetry-to-project-python-requirement-tag-migration.toml");
         assertKeyExists(TomlUtils.PROJECT, TomlUtils.REQUIRES_PYTHON, false);
     }
 
@@ -59,21 +78,8 @@ public class PoetryToProjectRequiresPythonMigrationSteps extends AbstractPoetryM
         assertKeyExists(TomlUtils.TOOL_POETRY_DEPENDENCIES, TomlUtils.PYTHON, false);
     }
 
-    @Given("an existing pyproject.toml file with a requires-python entry in the project group")
-    public void an_existing_pyproject_toml_file_with_a_requires_python_entry_in_project_group() {
-        pyProjectToml = new File(testTomlFileDirectory, "with-requires-python-in-project.toml");
-        assertKeyExists(TomlUtils.PROJECT, TomlUtils.REQUIRES_PYTHON, true);
-    }
-
-    @Given("an existing pyproject.toml file with no requires-python")
-    public void an_existing_pyproject_toml_file_without_a_requires_python_entry_in_project_group() {
-        pyProjectToml = new File(testTomlFileDirectory, "no-poetry-to-project-requires-python-migration.toml");
-        assertKeyExists(TomlUtils.PROJECT, TomlUtils.REQUIRES_PYTHON, false);
-    }
-
     @Then("the poetry to project requires python migration did not execute")
     public void the_poetry_to_project_requires_python_migration_did_not_execute() {
         assertFalse(shouldExecute, "Migration execution should have been skipped!");
     }
-
 }

--- a/habushu-maven-plugin/src/test/resources/migration/poetry-v2/no-poetry-to-project-python-requirement-tag-migration.toml
+++ b/habushu-maven-plugin/src/test/resources/migration/poetry-v2/no-poetry-to-project-python-requirement-tag-migration.toml
@@ -1,24 +1,23 @@
 [project]
-name = "with-no-requires-python-in-project"
-description = "Test adding requires-python entry to project when Poetry version is at least 2.0.0 and python dependency exists in tool.poetry.dependencies"
+name = "no-poetry-to-project-python-requirement-tag-migration"
+description = "Test skipping poetry-to-project-requires-python migration when Poetry version is less than 2.0.0"
 version = "2.9.0.dev"
 authors = [{name = "Test", email = "blah@foobar.com"}]
 maintainers = [{name = "Test", email = "blah@foobar.com"}]
 license = "MIT License"
-dynamic = ["version", "dependencies"]
 
 [tool.poetry]
 packages = [{include = "example_1", from = "src"}]
-readme = ["README.md"]
+readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.11"
 krausening = "19"
 cryptography = "^42.0.0"
 uvicorn = {version = "^0.18.0", extras = ["standard"]}
 
 [tool.poetry.group.dev.dependencies]
 kappa-maki = ">=1.0.0"
+
 
 [build-system]
 requires = ["poetry-core>=1.6.0"]

--- a/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-no-python-requirement-tag-in-project.toml
+++ b/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-no-python-requirement-tag-in-project.toml
@@ -1,0 +1,25 @@
+[project]
+name = "with-no-python-requirement-tag-in-project"
+description = "Test adding requires python entry to project when Poetry version is at least 2.0.0 and python dependency exists in tool.poetry.dependencies"
+version = "2.9.0.dev"
+authors = [{name = "Test", email = "blah@foobar.com"}]
+maintainers = [{name = "Test", email = "blah@foobar.com"}]
+license = "MIT License"
+dynamic = ["version", "dependencies"]
+
+[tool.poetry]
+packages = [{include = "example_1", from = "src"}]
+readme = ["README.md"]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+krausening = "19"
+cryptography = "^42.0.0"
+uvicorn = {version = "^0.18.0", extras = ["standard"]}
+
+[tool.poetry.group.dev.dependencies]
+kappa-maki = ">=1.0.0"
+
+[build-system]
+requires = ["poetry-core>=1.6.0"]
+build-backend = "poetry.core.masonry.api"

--- a/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-python-requirement-tag-in-project-badly-formatted.toml
+++ b/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-python-requirement-tag-in-project-badly-formatted.toml
@@ -1,14 +1,15 @@
 [project]
-name = "no-poetry-to-project-requires-python-migration"
-description = "Test skipping poetry-to-project-requires-python migration when Poetry version is less than 2.0.0"
+name = "with-python-requirement-tag-in-project-badly-formatted"
+description = "Test skipping migration when requires python entry already exists under project"
 version = "2.9.0.dev"
 authors = [{name = "Test", email = "blah@foobar.com"}]
 maintainers = [{name = "Test", email = "blah@foobar.com"}]
 license = "MIT License"
+dynamic = ["version", "dependencies"]
+requires-python = "^3.11"
 
 [tool.poetry]
 packages = [{include = "example_1", from = "src"}]
-readme = "README.md"
 
 [tool.poetry.dependencies]
 krausening = "19"
@@ -17,7 +18,6 @@ uvicorn = {version = "^0.18.0", extras = ["standard"]}
 
 [tool.poetry.group.dev.dependencies]
 kappa-maki = ">=1.0.0"
-
 
 [build-system]
 requires = ["poetry-core>=1.6.0"]

--- a/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-python-requirement-tag-in-project.toml
+++ b/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-python-requirement-tag-in-project.toml
@@ -1,12 +1,12 @@
 [project]
-name = "with-requires-python-in-project"
-description = "Test skipping migration when requires-python entry already exists under project"
+name = "with-python-requirement-tag-in-project"
+description = "Test skipping migration when requires python entry already exists under project"
 version = "2.9.0.dev"
 authors = [{name = "Test", email = "blah@foobar.com"}]
 maintainers = [{name = "Test", email = "blah@foobar.com"}]
 license = "MIT License"
 dynamic = ["version", "dependencies"]
-requires-python = "^3.11"
+requires-python = ">=3.11,<4"
 
 [tool.poetry]
 packages = [{include = "example_1", from = "src"}]

--- a/habushu-maven-plugin/src/test/resources/specifications/poetry-v2/poetry-to-project-requires-python-migration.feature
+++ b/habushu-maven-plugin/src/test/resources/specifications/poetry-v2/poetry-to-project-requires-python-migration.feature
@@ -5,7 +5,7 @@ Feature: Test automatic migrations of python dependency from [tool.project] to [
     Given Poetry version is at least "2.0.0"
     And an existing pyproject.toml file with no requires-python entry in the project group
     When the Habushu poetry-to-project-requires-python migration executes
-    Then the requires-python entry is added to the project group and set to "^3.11"
+    Then the requires-python entry is added to the project group and set to ">=3.11,<4"
     And the python entry no longer exists in the tool.poetry.dependencies group
 
   Scenario: Poetry version is at least 2.0.0 and project group already has a requires-python entry so the migration does not execute
@@ -13,6 +13,12 @@ Feature: Test automatic migrations of python dependency from [tool.project] to [
     And an existing pyproject.toml file with a requires-python entry in the project group
     When the Habushu poetry-to-project-requires-python migration executes
     Then the poetry to project requires python migration did not execute
+
+  Scenario: Poetry version is at least 2.0.0 and project group already has a requires-python entry in "^" format, so the migration executes and alters it to ">=,<" format
+    Given Poetry version is at least "2.0.0"
+    And an existing pyproject.toml file with a badly formatted requires-python entry in the project group
+    When the Habushu poetry-to-project-requires-python migration executes
+    Then the requires-python entry is added to the project group and set to ">=3.11,<4"
 
   Scenario: Poetry version is less than 2.0.0 so the migration does not execute
     Given Poetry version is less than "2.0.0"


### PR DESCRIPTION
#266

Updates existing Poetry migration for setting the target python version. Adds logic to make sure the migration inserts target python versions using the syntax Poetry expects for `requires-python` under the `[project]` section in `pyproject.toml` (use of ^ has been deprecated for this specific field as part of PEP440).