### PR TITLE
[#315] Update all python references to match default 3.12.9

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -24,7 +24,7 @@ jobs:
             - name: Install Python # use direct install rather than pyenv for CI for large speed improvement
               uses: actions/setup-python@v5
               with:
-                python-version: '3.11.9'
+                python-version: '3.12.9'
 
             - name: Load cached Poetry installation
               id: cached-poetry

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
             - name: Install Python # use direct install rather than pyenv for CI for large speed improvement
               uses: actions/setup-python@v5
               with:
-                  python-version: '3.11.9'
+                  python-version: '3.12.9'
             - name: Install Poetry
               uses: snok/install-poetry@v1
             - name: Set up JDK 11

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ All Habushu configurations may be set either via the `habushu-maven-plugin`'s `<
     <artifactId>habushu-maven-plugin</artifactId>
     <extensions>true</extensions>
     <configuration>
-        <pythonVersion>3.10.4</pythonVersion>
+        <pythonVersion>3.12.9</pythonVersion>
     </configuration>
 </plugin>
 ```
@@ -204,14 +204,14 @@ All Habushu configurations may be set either via the `habushu-maven-plugin`'s `<
 2. `-D` via command line
 
 ```shell
-mvn clean install -Dhabushu.pythonVersion=3.10.4
+mvn clean install -Dhabushu.pythonVersion=3.12.9
 ```
 
 3. POM properties
 
 ```xml
 	<properties>
-    <habushu.pythonVersion>3.10.4</habushu.pythonVersion>
+    <habushu.pythonVersion>3.12.9</habushu.pythonVersion>
 </properties>
 ```
 

--- a/examples/add-habushu-to-new-or-existing-uv-project/pyproject.toml
+++ b/examples/add-habushu-to-new-or-existing-uv-project/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 authors = [
     { name = "Margaret Black", email = "black_margaret@bah.com" }
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = [
     "ruff>=0.9.9",
 ]

--- a/examples/habushu-containerize/habushu-poetry-containerize/pyproject.toml
+++ b/examples/habushu-containerize/habushu-poetry-containerize/pyproject.toml
@@ -4,7 +4,7 @@ version = "3.0.0.dev"
 description = "Example of how to use the habushu-maven-plugin to containerize an application"
 authors = [{name = "Isaac Becerra Llanos", email = "ibecerrallanos@cpointe-inc.com"}]
 license = "MIT License"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dynamic = ["version", "dependencies"]
 
 [tool.poetry.dependencies]

--- a/examples/habushu-default-python-strategy/pyproject.toml
+++ b/examples/habushu-default-python-strategy/pyproject.toml
@@ -6,7 +6,7 @@ version = "3.0.0.dev"
 description = "Example of how to use the habushu default python strategy configuration"
 authors = [{name = "Ryan Ashcraft", email = "ryan.ashcraft@codifyiq.com"}]
 license = "MIT License"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dynamic = ["version", "dependencies"]
 
 [tool.poetry.dependencies]

--- a/examples/habushu-export-requirements-with-path-dependencies/pyproject.toml
+++ b/examples/habushu-export-requirements-with-path-dependencies/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 authors = [
     { name = "Margaret Black", email = "black_margaret@bah.com" }
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = [
     "habushu-uv-package",
 ]

--- a/examples/habushu-managed-dependencies/pyproject.toml
+++ b/examples/habushu-managed-dependencies/pyproject.toml
@@ -6,7 +6,7 @@ version = "3.0.0.dev"
 description = "Example of how to use the habushu managed dependencies"
 authors = [{name = "Ryan Ashcraft", email = "ryan.ashcraft@codifyiq.com"}]
 license = "MIT License"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dynamic = ["version", "dependencies"]
 
 [tool.poetry.dependencies]

--- a/examples/habushu-poetry-package-consumer/pyproject.toml
+++ b/examples/habushu-poetry-package-consumer/pyproject.toml
@@ -6,7 +6,7 @@ version = "3.0.0.dev"
 description = "Example of how to use the habushu-maven-plugin to consume other Habushu modules"
 authors = [{name = "Eric Konieczny", email = "ekoniec1@gmail.com"}]
 license = "MIT License"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dynamic = ["version", "dependencies"]
 
 [tool.poetry.dependencies]

--- a/examples/habushu-poetry-package/pyproject.toml
+++ b/examples/habushu-poetry-package/pyproject.toml
@@ -6,7 +6,7 @@ version = "3.0.0.dev"
 description = "Example of how to use the habushu-maven-plugin"
 authors = [{name = "Eric Konieczny", email = "ekoniec1@gmail.com"}]
 license = "MIT License"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dynamic = ["version", "dependencies"]
 
 [tool.poetry.dependencies]

--- a/examples/habushu-running-python-scripts/pyproject.toml
+++ b/examples/habushu-running-python-scripts/pyproject.toml
@@ -6,7 +6,7 @@ version = "3.0.0.dev"
 description = "Example of how to use Habushu's runCommandArgs in the run-command-in-virtual-env goal"
 authors = [{name = "Clay Woods", email = "cwoods@cpointe-inc.com"}]
 license = "MIT License"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dynamic = ["version", "dependencies"]
 
 [tool.poetry.dependencies]

--- a/examples/habushu-uv-package/pyproject.toml
+++ b/examples/habushu-uv-package/pyproject.toml
@@ -3,7 +3,7 @@ authors = [
     {name = "James Choi", email = "choi_james@bah.com"},
 ]
 license = {text = "MIT License"}
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = [
     "krausening>=20",
     "cryptography>=44.0.1",

--- a/habushu-maven-plugin/src/test/resources/containerize-dependencies/default-single-monorepo-dep/test-monorepo/extensions/extensions-python-dep-X/pyproject.toml
+++ b/habushu-maven-plugin/src/test/resources/containerize-dependencies/default-single-monorepo-dep/test-monorepo/extensions/extensions-python-dep-X/pyproject.toml
@@ -8,7 +8,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.11.4, <4"
+python = ">=3.12.9, <4"
 
 [tool.poetry.group.dev.dependencies]
 ruff = ">=0.9.9"

--- a/habushu-maven-plugin/src/test/resources/containerize-dependencies/default-single-monorepo-dep/test-monorepo/foundation/foundation-python-dep-Y/pyproject.toml
+++ b/habushu-maven-plugin/src/test/resources/containerize-dependencies/default-single-monorepo-dep/test-monorepo/foundation/foundation-python-dep-Y/pyproject.toml
@@ -8,7 +8,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.11.4, <4"
+python = ">=3.12.9, <4"
 
 [tool.poetry.group.dev.dependencies]
 ruff = ">=0.9.9"

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.technologybrewery</groupId>
         <artifactId>parent</artifactId>
-        <version>11</version>
+        <version>12</version>
     </parent>
 
     <groupId>org.technologybrewery.habushu</groupId>


### PR DESCRIPTION
- Update all docs and example projects to use python version `3.12.9`
- Update `Parent` from `v11` to `v12` so that `version.python.default` points to `3.12.9`