### PR TITLE
[#326] Add enablePypiSimpleSuffix to allow for empty pypiSimpleSuffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ and Maven Build Cache Configuration. All require manual action to enable.
 #### Maven Build Directory Customization ####
 Update Maven's build configuration to point to the `dist` directory for output in the pom file for each Habushu module:
 ```xml
-    <build>
+<build>
     <directory>dist</directory>
     ...
 </build>
@@ -191,7 +191,7 @@ All Habushu configurations may be set either via the `habushu-maven-plugin`'s `<
 1. Plugin `<configuration>`
 
 ```xml
-	<plugin>
+<plugin>
     <groupId>org.technologybrewery.habushu</groupId>
     <artifactId>habushu-maven-plugin</artifactId>
     <extensions>true</extensions>
@@ -210,7 +210,7 @@ mvn clean install -Dhabushu.pythonVersion=3.12.9
 3. POM properties
 
 ```xml
-	<properties>
+<properties>
     <habushu.pythonVersion>3.12.9</habushu.pythonVersion>
 </properties>
 ```
@@ -324,7 +324,7 @@ If this property is **not** specified, this property will default to `pypi` and 
 This property will typically be specified as a command line option during the `deploy` lifecycle phase.  For example, given the following configuration in the utilized `settings.xml`:
 
 ```xml
-    <server>
+<server>
     <id>private-pypi-repo</id>
     <username>pypi-repo-username</username>
     <password>{encrypted-pypi-repo-password}</password>
@@ -345,7 +345,7 @@ Specifies the URL of the private PyPI repository to which this project's archive
 If the Habushu project depends on internal packages that may only be found on a private PyPI repository, developers should specify this property through the plugin's `<configuration>` definition:
 
 ```xml
-	<plugin>
+<plugin>
     <groupId>org.technologybrewery.habushu</groupId>
     <artifactId>habushu-maven-plugin</artifactId>
     <extensions>true</extensions>
@@ -357,15 +357,21 @@ If the Habushu project depends on internal packages that may only be found on a 
 
 Default: None
 
+#### enablePypiSimpleSuffix ####
+
+Determines whether to append the path to the simple index relative to the given PyPi repository URL.
+
+Default: `true`
+
 #### pypiSimpleSuffix ####
 
-Specifies the path to the simple index relative to the pypiRepoUrl.  Certain private repository solutions use non-standard paths (ie: devpi uses `+simple`).
+Specifies the path to the simple index relative to the `pypiRepoUrl`.  Certain private repository solutions use non-standard paths (ie: devpi uses `+simple`). `enablePypiSimpleSuffix` must be set to `true` to enable usage.
 
 Default: `simple`
 
 #### pypiUploadSuffix ####
 
-Specifies the path to the upload index relative to the pypiRepoUrl.  Certain private repository solutions use
+Specifies the path to the upload index relative to the `pypiRepoUrl`.  Certain private repository solutions use
 non-standard paths.
 
 Default: None
@@ -413,7 +419,7 @@ This property will typically be specified as a command line option during the `d
 given the following configuration in the utilized `settings.xml`:
 
 ```xml
-    <server>
+<server>
     <id>dev-pypi</id>
     <username>pypi-repo-username</username>
     <password>{encrypted-pypi-repo-password}</password>
@@ -438,7 +444,7 @@ If the Habushu project depends on internal packages that may only be found on a 
 developers should specify this property through the plugin's `<configuration>` definition:
 
 ```xml
-	<plugin>
+<plugin>
     <groupId>org.technologybrewery.habushu</groupId>
     <artifactId>habushu-maven-plugin</artifactId>
     <extensions>true</extensions>
@@ -451,7 +457,7 @@ Default: `https://test.pypi.org`
 
 #### enableDevRepositoryUrlUploadSuffix ####
 
-enables whether to append the path to the upload index relative to the devRepositoryUrl.
+Enables whether to append the path to the upload index relative to the `devRepositoryUrl`.
 
 Default: `true`
 
@@ -812,13 +818,11 @@ the `habushu-maven-plugin`, a single build may be used to build `habushu-maven-p
 * `mvnd clean install -Pdefault`: (ACTIVE BY DEFAULT - `-Pdefault` does not need to be specified) builds all modules.  Developers may use this profile to build and apply changes to existing `habushu-maven-plugin` `Mojo` classes
 
 ## Poetry v2.0.0+ Changes ##
-When on Poetry v2.0.0 and later, Baton migrations will automatically run on all `pyproject.toml` files in your Habushu project.
-This update introduces three migrations that ensure configurations are more in line with [PEP 621](https://peps.python.org/pep-0621/). 
+When on Poetry v2.0.0 and later, Baton migrations will automatically run on all `pyproject.toml` and `poetry.toml` files in your Habushu project.
+This update introduces a number of migrations that ensure configurations are more in line with [PEP 621](https://peps.python.org/pep-0621/).
 - `PoetryToProjectMigration`: Adds `[project]` section into TOML file and moves relevant fields from `[tool.poetry]` to `[project]`
 - `PoetryToProjectRequiresPythonMigration`: Relocates the Python dependency from `[tool.poetry.dependencies]` to the `requires-python` entry under `[project]`
 - `PoetryToProjectDynamicMigration`: Introduces a `dynamic` field under `[project]` that automatically includes `version` and `dependency`, if not already present. If a single `readme` (as a string) is included in `[tool.poetry]`, then migrates it from `[tool.poetry]` to `[project]`. If multiple `readme` values are defined (as a table) in `[tool.poetry]`, `readme` is added to the `dynamic` field list.
+- `PoetryTomlMigration`: Removes deprecated configurations from the `poetry.toml` file
 
 **Note:** Baton migrations are forward compatible only. If you upgrade to Poetry v2.0+ and later decide to downgrade, you will need to manually revert the changes in your TOML files.
-
-
-

--- a/examples/uv/habushu-uv-add-to-project/pyproject.toml
+++ b/examples/uv/habushu-uv-add-to-project/pyproject.toml
@@ -29,17 +29,15 @@ dev = [
     "kappa-maki>=1.0.2",
 ]
 
-
-# Added by habushu-maven-plugin at 2025-03-18T10:40:05.176687 to use https://pypi.org/simple/ as source PyPi repository for installing dependencies
+# Added by habushu-maven-plugin at 2025-04-09T14:26:42.416126 to use https://pypi.org/simple/ as source repository for installing dependencies
 [[tool.uv.index]]
 name = "pypi"
 url = "https://pypi.org/simple/"
 publish-url = "https://pypi.org/simple/"
 
 
-# Added by habushu-maven-plugin at 2025-03-18T10:40:05.178201 to use https://test.pypi.org/simple/ as source PyPi repository for installing dependencies
+# Added by habushu-maven-plugin at 2025-04-09T14:26:42.420929 to use https://test.pypi.org/simple/ as source PyPi repository for installing dependencies
 [[tool.uv.index]]
 name = "dev-pypi"
 url = "https://test.pypi.org/simple/"
 publish-url = "https://test.pypi.org/legacy/"
-priority = "supplemental"

--- a/examples/uv/habushu-uv-containerize/pyproject.toml
+++ b/examples/uv/habushu-uv-containerize/pyproject.toml
@@ -21,17 +21,15 @@ indent-style="space"
 line-ending="lf"
 quote-style="preserve"
 
-
-# Added by habushu-maven-plugin at 2025-03-28T16:24:39.161900 to use https://pypi.org/simple/ as source PyPi repository for installing dependencies
+# Added by habushu-maven-plugin at 2025-04-09T09:49:15.815876 to use https://pypi.org/simple/ as source repository for installing dependencies
 [[tool.uv.index]]
 name = "pypi"
 url = "https://pypi.org/simple/"
 publish-url = "https://pypi.org/simple/"
 
 
-# Added by habushu-maven-plugin at 2025-03-28T16:24:39.162921 to use https://test.pypi.org/simple/ as source PyPi repository for installing dependencies
+# Added by habushu-maven-plugin at 2025-04-09T09:49:15.816809 to use https://test.pypi.org/simple/ as source PyPi repository for installing dependencies
 [[tool.uv.index]]
 name = "dev-pypi"
 url = "https://test.pypi.org/simple/"
 publish-url = "https://test.pypi.org/legacy/"
-priority = "supplemental"

--- a/examples/uv/habushu-uv-disable-export-with-path-dependencies/pyproject.toml
+++ b/examples/uv/habushu-uv-disable-export-with-path-dependencies/pyproject.toml
@@ -29,16 +29,15 @@ dev = [
 ]
 
 
-# Added by habushu-maven-plugin at 2025-03-18T10:40:07.659305 to use https://pypi.org/simple/ as source PyPi repository for installing dependencies
+# Added by habushu-maven-plugin at 2025-04-09T09:49:19.699463 to use https://pypi.org/simple/ as source repository for installing dependencies
 [[tool.uv.index]]
 name = "pypi"
 url = "https://pypi.org/simple/"
 publish-url = "https://pypi.org/simple/"
 
 
-# Added by habushu-maven-plugin at 2025-03-18T10:40:07.660203 to use https://test.pypi.org/simple/ as source PyPi repository for installing dependencies
+# Added by habushu-maven-plugin at 2025-04-09T09:49:19.700120 to use https://test.pypi.org/simple/ as source PyPi repository for installing dependencies
 [[tool.uv.index]]
 name = "dev-pypi"
 url = "https://test.pypi.org/simple/"
 publish-url = "https://test.pypi.org/legacy/"
-priority = "supplemental"

--- a/examples/uv/habushu-uv-install-from-dev-repo/pom.xml
+++ b/examples/uv/habushu-uv-install-from-dev-repo/pom.xml
@@ -34,6 +34,9 @@
                 <groupId>org.technologybrewery.habushu</groupId>
                 <artifactId>habushu-maven-plugin</artifactId>
                 <!-- See habushu/examples/pom.xml for additional plugin configuration details -->
+                <configuration>
+                    <useDevRepository>false</useDevRepository>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/examples/uv/habushu-uv-install-from-dev-repo/pyproject.toml
+++ b/examples/uv/habushu-uv-install-from-dev-repo/pyproject.toml
@@ -26,20 +26,15 @@ dev = [
     "ruff>=0.11.4",
 ]
 
-# Added by habushu-maven-plugin at 2025-04-08T09:57:15.989477 to use https://pypi.org/simple/ as source repository for installing dependencies
+# Added by habushu-maven-plugin at 2025-04-09T10:35:14.766890 to use https://pypi.org/simple/ as source repository for installing dependencies
 [[tool.uv.index]]
 name = "pypi"
 url = "https://pypi.org/simple/"
 publish-url = "https://pypi.org/simple/"
 
+
+# Added by habushu-maven-plugin at 2025-04-09T10:38:54.299633 to use http://127.0.0.1:8080/simple/ as source PyPi repository for installing dependencies
 [[tool.uv.index]]
 name = "private-repo"
 url = "http://127.0.0.1:8080/simple/"
 publish-url = "http://127.0.0.1:8080/"
-
-# Added by habushu-maven-plugin at 2025-04-09T13:26:38.032770 to use https://test.pypi.org/simple/ as source PyPi repository for installing dependencies
-[[tool.uv.index]]
-name = "dev-pypi"
-url = "https://test.pypi.org/simple/"
-publish-url = "https://test.pypi.org/legacy/"
-priority = "supplemental"

--- a/examples/uv/habushu-uv-package/pyproject.toml
+++ b/examples/uv/habushu-uv-package/pyproject.toml
@@ -36,17 +36,15 @@ indent-style="space"
 line-ending="lf"
 quote-style="preserve"
 
-
-# Added by habushu-maven-plugin at 2025-03-17T15:33:50.608826 to use https://pypi.org/simple/ as source PyPi repository for installing dependencies
+# Added by habushu-maven-plugin at 2025-04-09T09:49:04.175061 to use https://pypi.org/simple/ as source repository for installing dependencies
 [[tool.uv.index]]
 name = "pypi"
 url = "https://pypi.org/simple/"
 publish-url = "https://pypi.org/simple/"
 
 
-# Added by habushu-maven-plugin at 2025-03-17T15:33:50.610325 to use https://test.pypi.org/simple/ as source PyPi repository for installing dependencies
+# Added by habushu-maven-plugin at 2025-04-09T09:49:04.176397 to use https://test.pypi.org/simple/ as source PyPi repository for installing dependencies
 [[tool.uv.index]]
 name = "dev-pypi"
 url = "https://test.pypi.org/simple/"
 publish-url = "https://test.pypi.org/legacy/"
-priority = "supplemental"

--- a/examples/uv/habushu-uv-publish-to-dev-repo/README.md
+++ b/examples/uv/habushu-uv-publish-to-dev-repo/README.md
@@ -105,7 +105,7 @@ In this example, the following configuration is located in the `deploy-example` 
     <useDevRepository>true</useDevRepository>
     <devRepositoryId>private-repo</devRepositoryId>
 
-    <!-- LEAVE OFF simple/ FROM THE END OF THE URL AS HABUSHU ADDS IT BACK FOR YOU -->
+    <!-- Leave off simple/ suffix to enable seamless upload and download capabilities -->
     <devRepositoryUrl>http://127.0.0.1:8080/</devRepositoryUrl>
     <enableDevRepositoryUrlUploadSuffix>false</enableDevRepositoryUrlUploadSuffix>
  </configuration>

--- a/examples/uv/habushu-uv-publish-to-dev-repo/pom.xml
+++ b/examples/uv/habushu-uv-publish-to-dev-repo/pom.xml
@@ -34,6 +34,9 @@
                 <groupId>org.technologybrewery.habushu</groupId>
                 <artifactId>habushu-maven-plugin</artifactId>
                 <!-- See habushu/examples/pom.xml for additional plugin configuration details -->
+                <configuration>
+                    <useDevRepository>false</useDevRepository>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/examples/uv/habushu-uv-publish-to-dev-repo/pyproject.toml
+++ b/examples/uv/habushu-uv-publish-to-dev-repo/pyproject.toml
@@ -13,19 +13,6 @@ dependencies = []
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-# Added by habushu-maven-plugin at 2025-04-07T11:48:27.694046 to use https://pypi.org/simple/ as source repository for installing dependencies
-[[tool.uv.index]]
-name = "pypi"
-url = "https://pypi.org/simple/"
-publish-url = "https://pypi.org/simple/"
-
-# Added by habushu-maven-plugin at 2025-04-07T11:48:27.696486 to use http://127.0.0.1:8080/simple/ as source PyPi repository for installing dependencies
-[[tool.uv.index]]
-name = "private-repo"
-url = "http://127.0.0.1:8080/simple/"
-publish-url = "http://127.0.0.1:8080/"
-priority = "supplemental"
-
 [tool.ruff.format]
 indent-style="space"
 line-ending="lf"
@@ -36,9 +23,15 @@ dev = [
     "ruff>=0.11.4",
 ]
 
-# Added by habushu-maven-plugin at 2025-04-08T10:17:04.753895 to use https://test.pypi.org/simple/ as source PyPi repository for installing dependencies
+# Added by habushu-maven-plugin at 2025-04-09T10:43:11.846365 to use https://pypi.org/simple/ as source repository for installing dependencies
 [[tool.uv.index]]
-name = "dev-pypi"
-url = "https://test.pypi.org/simple/"
-publish-url = "https://test.pypi.org/legacy/"
-priority = "supplemental"
+name = "pypi"
+url = "https://pypi.org/simple/"
+publish-url = "https://pypi.org/simple/"
+
+
+# Added by habushu-maven-plugin at 2025-04-09T10:47:56.854887 to use http://127.0.0.1:8080/simple/ as source PyPi repository for installing dependencies
+[[tool.uv.index]]
+name = "private-repo"
+url = "http://127.0.0.1:8080/simple/"
+publish-url = "http://127.0.0.1:8080/"

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/AbstractInstallDependencies.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/AbstractInstallDependencies.java
@@ -109,8 +109,10 @@ public abstract class AbstractInstallDependencies {
                 if (HabushuUtil.isCurrentPackageManagerUv(getPyProjectTomlFile()) ) {
                     newPypiRepoSourceConfig.add(String.format("publish-url = \"%s\"", getPublishUrl(repoUrl, !HabushuUtil.PUBLIC_PYPI_REPO_ID.equals(repoId))));
                 }
-                newPypiRepoSourceConfig.add("priority = \"supplemental\"");
 
+                if (shouldAddPriority()){
+                    newPypiRepoSourceConfig.add("priority = \"supplemental\"");
+                }
 
                 log.info(String.format("Private PyPi repository entry for %s not found in pyproject.toml",
                         repoUrl));
@@ -131,10 +133,11 @@ public abstract class AbstractInstallDependencies {
 
     /**
      * Attempts to infer the PEP-503 compliant PyPI simple repository index URL
-     * associated with the provided PyPI repository URL. In order to configure
-     * UV or Poetry to use a private PyPi repository as a source for installing package
-     * dependencies, the simple index URL of the repository <b>*must*</b> be
-     * utilized. For example, if a private PyPI repository is hosted at
+     * associated with the provided PyPI repository URL if the {@code enablePypiSimpleSuffix}
+     * flag is enabled (default is {@code true}).
+     * In most cases, in order to configure UV or Poetry to use a private PyPi repository as a
+     * source for installing package dependencies, the simple index URL of the repository <b>*must*</b>
+     * be utilized. For example, if a private PyPI repository is hosted at
      * https://my-company-sonatype-nexus/repository/internal-pypi and provided to
      * Habushu via the {@literal <pypiRepoUrl>} configuration, the simple index URL
      * returned by this method will be
@@ -152,7 +155,7 @@ public abstract class AbstractInstallDependencies {
         String lastPathSegment = CollectionUtils.isNotEmpty(repoUriPathSegments)
                 ? repoUriPathSegments.get(repoUriPathSegments.size() - 1)
                 : null;
-        if (!installDependenciesMojo.pypiSimpleSuffix.equals(lastPathSegment)) {
+        if (installDependenciesMojo.enablePypiSimpleSuffix() && !installDependenciesMojo.pypiSimpleSuffix.equals(lastPathSegment)) {
             // If the URL has no path, an unmodifiable Collections.emptyList() is returned,
             // so wrap in an ArrayList to enable later modifications
             repoUriPathSegments = new ArrayList<>(repoUriPathSegments);
@@ -191,4 +194,6 @@ public abstract class AbstractInstallDependencies {
 
         return matchingPypiRepoIndexConfig;
     }
+
+    protected abstract boolean shouldAddPriority();
 }

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/InstallDependenciesMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/InstallDependenciesMojo.java
@@ -32,6 +32,15 @@ public class InstallDependenciesMojo extends AbstractHabushuMojo {
     protected boolean addPypiRepoAsPackageSources;
 
     /**
+     * Determines if pypiSimpleSuffix is enabled or not.
+     * Setting enablePypiSimpleSuffix to false will set pypiSimpleSuffix to empty value regardless
+     * of pypiSimpleSuffix property value.
+     * Setting enablePypiSimpleSuffix to true will honor pypiSimpleSuffix property value.
+     */
+    @Parameter(property = "habushu.enablePypiSimpleSuffix", defaultValue = "true")
+    protected boolean enablePypiSimpleSuffix;
+
+    /**
      * Configures the path for the simple index on a private pypi repository.
      * Certain private repository solutions (ie: devpi) use different names for the
      * simple index. devpi, for instance, uses "+simple".
@@ -108,10 +117,10 @@ public class InstallDependenciesMojo extends AbstractHabushuMojo {
     protected String pypiUploadSuffix = "";
 
     /**
-     * whether we enable devRepositoryUrlUploadSuffix.
-     * Setting devRepositoryUrlUploadSuffix to false will set devRepositoryUrlUploadSuffix to empty value regardless
+     * Determines whether we enable devRepositoryUrlUploadSuffix.
+     * Setting enableDevRepositoryUrlUploadSuffix to false will set devRepositoryUrlUploadSuffix to empty value regardless
      * of devRepositoryUrlUploadSuffix property value.
-     * Setting devRepositoryUrlUploadSuffix to true will honor devRepositoryUrlUploadSuffix property values.
+     * Setting enableDevRepositoryUrlUploadSuffix to true will honor devRepositoryUrlUploadSuffix property values.
      */
     @Parameter(property = "habushu.enableDevRepositoryUrlUploadSuffix", defaultValue = "true")
     protected boolean enableDevRepositoryUrlUploadSuffix;
@@ -125,11 +134,19 @@ public class InstallDependenciesMojo extends AbstractHabushuMojo {
     protected String devRepositoryUrlUploadSuffix;
 
     /**
-     * Get whether whether a private PyPi repository, is automatically added as a package source
+     * Get whether a private PyPi repository, is automatically added as a package source
      * @return addPypiRepoAsPackageSources
      */
     public boolean addPypiRepoAsPackageSources() {
         return addPypiRepoAsPackageSources;
+    }
+
+    /**
+     * Whether to enable path for the simple index on a pypi repository.
+     * @return enablePypiSimpleSuffix
+     */
+    public boolean enablePypiSimpleSuffix() {
+        return enablePypiSimpleSuffix;
     }
 
     /**

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/InstallDependenciesPoetry.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/InstallDependenciesPoetry.java
@@ -300,4 +300,8 @@ public class InstallDependenciesPoetry extends AbstractInstallDependencies {
         return toolPoetryGroupSections;
     }
 
+    @Override
+    protected boolean shouldAddPriority() {
+        return true;
+    }
 }

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/InstallDependenciesUv.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/InstallDependenciesUv.java
@@ -99,14 +99,7 @@ public class InstallDependenciesUv extends AbstractInstallDependencies {
     }
 
     private void prepareDefaultRepositoryForInstallation() {
-        String pypiRepoSimpleIndexUrl;
-        try {
-            pypiRepoSimpleIndexUrl = getPyPiRepoSimpleIndexUrl(PUBLIC_PYPI_REPO_URL);
-        } catch (URISyntaxException e) {
-            throw new HabushuException(
-                    String.format("Could not parse configured repoUrl %s", PUBLIC_PYPI_REPO_URL), e);
-        }
-        Config matchingPypiRepoIndexConfig = getMatchingPypiRepoIndexConfig(PYPROJECT_PACKAGE_INDEX_PATH, pypiRepoSimpleIndexUrl);
+        Config matchingPypiRepoIndexConfig = getMatchingPypiRepoIndexConfig(PYPROJECT_PACKAGE_INDEX_PATH, PUBLIC_PYPI_REPO_URL);
 
         if (!matchingPypiRepoIndexConfig.isEmpty()) {
             if (log.isDebugEnabled()) {
@@ -120,7 +113,7 @@ public class InstallDependenciesUv extends AbstractInstallDependencies {
             // Therefore, if we need to specify supplemental sources, we need to populate default ( or explicit) source first.
             List<String> defaultPypiRepoIndexConfig = Arrays.asList(System.lineSeparator(), String.format(
                             "# Added by habushu-maven-plugin at %s to use %s as source repository for installing dependencies",
-                            LocalDateTime.now(), pypiRepoSimpleIndexUrl),
+                            LocalDateTime.now(), PUBLIC_PYPI_REPO_URL),
                     String.format("[[%s]]", PYPROJECT_PACKAGE_INDEX_PATH),
                     String.format("name = \"%s\"", HabushuUtil.PUBLIC_PYPI_REPO_ID),
                     String.format("url = \"%s\"", PUBLIC_PYPI_REPO_URL),
@@ -290,5 +283,10 @@ public class InstallDependenciesUv extends AbstractInstallDependencies {
      */
     protected UvAuthenticationCommandHelper createUvAuthenticationCommandHelper() {
         return new UvAuthenticationCommandHelper(baseDir, null, installDependenciesMojo);
+    }
+
+    @Override
+    protected boolean shouldAddPriority() {
+        return false;
     }
 }

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/exec/UvAuthenticationCommandHelper.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/exec/UvAuthenticationCommandHelper.java
@@ -182,7 +182,7 @@ public class UvAuthenticationCommandHelper extends AbstractCommandHelper {
         String uvIndexPasswordEnvironmentVariable = getUvIndexPasswordEnvironmentVariable(repoId);
 
         if (username==null && password==null) {
-            throw new HabushuException("Your credentials for " + repoId + " must be set in your ~/.m2/settings.xml" +
+            throw new HabushuException("Your credentials for " + repoId + " must be set in your ~/.m2/settings.xml. " +
                     "Visit the Publish to Development Repository and Install from Development Repository uv examples for additional configuration details.");
         } else {
             credentials.put(uvIndexUsernameEnvironmentVariable, username);

--- a/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/InstallPhaseSteps.java
+++ b/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/InstallPhaseSteps.java
@@ -1,0 +1,81 @@
+package org.technologybrewery.habushu;
+
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URISyntaxException;
+
+public class InstallPhaseSteps {
+    protected TestInstallDependenciesMojo installMojo = new TestInstallDependenciesMojo();
+
+    @Given("the PyPi simple suffix is enabled")
+    public void the_pypi_simple_suffix_is_enabled(){
+        installMojo.enablePypiSimpleSuffix = true;
+    }
+
+    @Given("the PyPi simple suffix is disabled")
+    public void the_pypi_simple_suffix_is_disabled(){
+        installMojo.enablePypiSimpleSuffix = false;
+    }
+
+    @Given("a custom PyPi repository URL is set to {string}")
+    public void a_custom_pypi_repository_url_is_set_to(String customRepositoryUrl){
+        installMojo.pypiRepoUrl = customRepositoryUrl;
+    }
+
+    @Given("the simple suffix is set to {string}")
+    public void the_simple_suffix_is_set_to(String pypiSimpleSuffix){
+        installMojo.pypiSimpleSuffix = pypiSimpleSuffix;
+    }
+
+    @When("the install phase executes")
+    public void the_install_phase_executes(){
+        // do nothing
+    }
+
+    @Then("the PyPi source URL added to the Poetry pyproject.toml is {string}")
+    public void the_pypi_source_url_added_to_poetry_pyproject_toml_is(String expectedPypiSourceUrl) throws URISyntaxException {
+        String actualPypiSourceUrl = installMojo.getPypiSimpleRepoUrl(installMojo.pypiRepoUrl, true);
+        assertEquals(expectedPypiSourceUrl, actualPypiSourceUrl, "Unexpected PyPi source repository URL!");
+    }
+
+    @Given("a custom dev PyPi repository URL is set to {string}")
+    public void a_custom_dev_pypi_repository_url_is_set_to(String customDevRepositoryUrl){
+        installMojo.useDevRepository = true;
+        installMojo.devRepositoryUrl = customDevRepositoryUrl;
+    }
+
+    @Then("the dev PyPi source URL added to the Poetry pyproject.toml is {string}")
+    public void the_dev_pypi_source_url_added_to_poetry_pyproject_toml_is(String expectedPypiSourceUrl) throws URISyntaxException {
+        String actualPypiSourceUrl = installMojo.getPypiSimpleRepoUrl(installMojo.devRepositoryUrl, true);
+        assertEquals(expectedPypiSourceUrl, actualPypiSourceUrl, "Unexpected dev PyPi source repository URL!");
+    }
+
+    @Then("the PyPi source URL added to the UV pyproject.toml is {string}")
+    public void the_pypi_source_url_added_to_uv_pyproject_toml_is(String expectedPypiSourceUrl) throws URISyntaxException {
+        String actualPypiSourceUrl = installMojo.getPypiSimpleRepoUrl(installMojo.pypiRepoUrl, false);
+        assertEquals(expectedPypiSourceUrl, actualPypiSourceUrl, "Unexpected PyPi source repository URL!");
+    }
+
+    @Then("the dev PyPi source URL added to the UV pyproject.toml is {string}")
+    public void the_dev_pypi_source_url_added_to_uv_pyproject_toml_is(String expectedPypiSourceUrl) throws URISyntaxException {
+        String actualPypiSourceUrl = installMojo.getPypiSimpleRepoUrl(installMojo.devRepositoryUrl, false);
+        assertEquals(expectedPypiSourceUrl, actualPypiSourceUrl, "Unexpected dev PyPi source repository URL!");
+    }
+
+    @Then("the PyPi source added to the Poetry pyproject.toml is noted as a \"supplemental\" priority")
+    public void the_pypi_source_added_to_poetry_pyproject_toml_is_noted_as_supplemental(){
+        assertTrue(installMojo.getShouldAddPriority(true));
+    }
+
+    @Then("the PyPi source added to the UV pyproject.toml is not noted as a \"supplemental\" priority")
+    public void the_pypi_source_added_to_uv_pyproject_toml_is_not_noted_as_supplemental(){
+        assertFalse(installMojo.getShouldAddPriority(false));
+    }
+
+}

--- a/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/TestInstallDependenciesMojo.java
+++ b/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/TestInstallDependenciesMojo.java
@@ -1,0 +1,50 @@
+package org.technologybrewery.habushu;
+
+import org.technologybrewery.habushu.util.HabushuUtil;
+
+import java.io.File;
+import java.net.URISyntaxException;
+
+/**
+ * Contains method to make testing easier and set deploy Mojo values that would be done by Maven in normal use.
+ */
+public class TestInstallDependenciesMojo extends InstallDependenciesMojo {
+
+    public TestInstallDependenciesMojo() {
+        super();
+
+        //mimic defaults in Mojo:
+        this.pypiRepoId = HabushuUtil.PUBLIC_PYPI_REPO_ID;
+        this.useDevRepository = false;
+        this.devRepositoryId = DEV_PYPI_REPO_ID;
+        this.devRepositoryUrl = TEST_PYPI_REPOSITORY_URL;
+
+        this.enablePypiSimpleSuffix = true;
+        this.pypiSimpleSuffix = "simple";
+    }
+
+    public String getPypiSimpleRepoUrl(String pypiRepoUrl, boolean isPoetry) throws URISyntaxException {
+        String pypiSimpleRepoUrl;
+        if (isPoetry){
+            InstallDependenciesPoetry installDependenciesPoetry = new InstallDependenciesPoetry(new File("target/"), getLog(), this);
+            pypiSimpleRepoUrl = installDependenciesPoetry.getPyPiRepoSimpleIndexUrl(pypiRepoUrl);
+        } else {
+            InstallDependenciesUv installDependenciesUv = new InstallDependenciesUv(new File("target/"), getLog(), this);
+            pypiSimpleRepoUrl = installDependenciesUv.getPyPiRepoSimpleIndexUrl(pypiRepoUrl);
+        }
+        return pypiSimpleRepoUrl;
+    }
+
+    public boolean getShouldAddPriority(boolean isPoetry){
+        boolean shouldAddPriority;
+        if (isPoetry){
+            InstallDependenciesPoetry installDependenciesPoetry = new InstallDependenciesPoetry(new File("target/"), getLog(), this);
+            shouldAddPriority = installDependenciesPoetry.shouldAddPriority();
+        } else {
+            InstallDependenciesUv installDependenciesUv = new InstallDependenciesUv(new File("target/"), getLog(), this);
+            shouldAddPriority = installDependenciesUv.shouldAddPriority();
+        }
+        return shouldAddPriority;
+    }
+
+}

--- a/habushu-maven-plugin/src/test/resources/specifications/add-pypi-source-repository-poetry.feature
+++ b/habushu-maven-plugin/src/test/resources/specifications/add-pypi-source-repository-poetry.feature
@@ -1,0 +1,41 @@
+@addPypiSourceRepoPoetry
+Feature: Test adding source PyPi repositories to pyproject.toml file for Poetry projects
+
+  Scenario Outline: Add PyPi source repository with simple suffix enabled
+    Given the PyPi simple suffix is enabled
+    And a custom PyPi repository URL is set to "https://nexus.github.com/habushu/"
+    And the simple suffix is set to "<pypiSimpleSuffix>"
+    When the install phase executes
+    Then the PyPi source URL added to the Poetry pyproject.toml is "<expectedPypiSourceUrl>"
+    Examples:
+    | pypiSimpleSuffix | expectedPypiSourceUrl                         |
+    | simple           | https://nexus.github.com/habushu/simple/      |
+    | simple-test      | https://nexus.github.com/habushu/simple-test/ |
+
+  Scenario: Add PyPi source repository with simple suffix disabled
+    Given the PyPi simple suffix is disabled
+    And a custom PyPi repository URL is set to "https://nexus.github.com/habushu/"
+    When the install phase executes
+    Then the PyPi source URL added to the Poetry pyproject.toml is "https://nexus.github.com/habushu/"
+
+  Scenario Outline: Add dev PyPi source repository with simple suffix enabled
+    Given the PyPi simple suffix is enabled
+    And a custom dev PyPi repository URL is set to "https://test.pypi.org/"
+    And the simple suffix is set to "<pypiSimpleSuffix>"
+    When the install phase executes
+    Then the dev PyPi source URL added to the Poetry pyproject.toml is "<expectedPypiSourceUrl>"
+    Examples:
+      | pypiSimpleSuffix | expectedPypiSourceUrl              |
+      | simple           | https://test.pypi.org/simple/      |
+      | simple-test      | https://test.pypi.org/simple-test/ |
+
+  Scenario: Add dev PyPi source repository with simple suffix disabled
+    Given the PyPi simple suffix is disabled
+    And a custom dev PyPi repository URL is set to "https://test.pypi.org/"
+    When the install phase executes
+    Then the dev PyPi source URL added to the Poetry pyproject.toml is "https://test.pypi.org/"
+
+  Scenario: Supplemental priority line is added for Poetry projects
+  Given a custom PyPi repository URL is set to "https://nexus.github.com/habushu/"
+  When the install phase executes
+  Then the PyPi source added to the Poetry pyproject.toml is noted as a "supplemental" priority

--- a/habushu-maven-plugin/src/test/resources/specifications/add-pypi-source-repository-uv.feature
+++ b/habushu-maven-plugin/src/test/resources/specifications/add-pypi-source-repository-uv.feature
@@ -1,0 +1,41 @@
+@addPypiSourceRepoUv
+Feature: Test adding source PyPi repositories to pyproject.toml file for UV projects
+
+  Scenario Outline: Add PyPi source repository with simple suffix enabled
+    Given the PyPi simple suffix is enabled
+    And a custom PyPi repository URL is set to "https://nexus.github.com/habushu/"
+    And the simple suffix is set to "<pypiSimpleSuffix>"
+    When the install phase executes
+    Then the PyPi source URL added to the UV pyproject.toml is "<expectedPypiSourceUrl>"
+    Examples:
+      | pypiSimpleSuffix | expectedPypiSourceUrl                         |
+      | simple           | https://nexus.github.com/habushu/simple/      |
+      | simple-test      | https://nexus.github.com/habushu/simple-test/ |
+
+  Scenario: Add PyPi source repository with simple suffix disabled
+    Given the PyPi simple suffix is disabled
+    And a custom PyPi repository URL is set to "https://nexus.github.com/habushu/"
+    When the install phase executes
+    Then the PyPi source URL added to the UV pyproject.toml is "https://nexus.github.com/habushu/"
+
+  Scenario Outline: Add dev PyPi source repository with simple suffix enabled
+    Given the PyPi simple suffix is enabled
+    And a custom dev PyPi repository URL is set to "https://test.pypi.org/"
+    And the simple suffix is set to "<pypiSimpleSuffix>"
+    When the install phase executes
+    Then the dev PyPi source URL added to the UV pyproject.toml is "<expectedPypiSourceUrl>"
+    Examples:
+      | pypiSimpleSuffix | expectedPypiSourceUrl              |
+      | simple           | https://test.pypi.org/simple/      |
+      | simple-test      | https://test.pypi.org/simple-test/ |
+
+  Scenario: Add dev PyPi source repository with simple suffix disabled
+    Given the PyPi simple suffix is disabled
+    And a custom dev PyPi repository URL is set to "https://test.pypi.org/"
+    When the install phase executes
+    Then the dev PyPi source URL added to the UV pyproject.toml is "https://test.pypi.org/"
+
+  Scenario: Supplemental priority line is not for UV projects
+    Given a custom PyPi repository URL is set to "https://nexus.github.com/habushu/"
+    When the install phase executes
+    Then the PyPi source added to the UV pyproject.toml is not noted as a "supplemental" priority


### PR DESCRIPTION
#326 
- created new `enablePypiSimpleSuffix` property
- removed `priority = "supplemental"` line from `[[tool.uv.index]]` since it's N/A
- updated documentation