### PR TITLE
[#355] Add version check when installing poetry plugin

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -62,5 +62,5 @@ jobs:
             - name: Build habushu-maven-plugin
               run: mvn -B install -Pbootstrap --file pom.xml
 
-            - name: Test habushu-maven-plugin (Poetry)
+            - name: Test habushu-maven-plugin
               run: mvn -B install --file pom.xml -Dhabushu.usePyenv=false

--- a/docs/CONFIGURATION_README.md
+++ b/docs/CONFIGURATION_README.md
@@ -110,6 +110,7 @@ mvn clean install -Dhabushu.pythonVersion=3.12.9
 - [Poetry-Specific Configurations](#poetry-specific-configurations)
   - [usePyenv](#usepyenv)
   - [useInProjectVirtualEnvironment](#useinprojectvirtualenvironment)
+  - [poetryMonorepoDependencyPluginVersion](#poetrymonorepodependencypluginversion)
 
 ## General Habushu Configurations
 
@@ -683,12 +684,6 @@ The version of the poetry-plugin-bundle to install in the container.
 
 Default: `1.5.0`
 
-#### dockerPoetryMonorepoDependencyPluginVersion
-
-The version of the poetry-monorepo-dependency-plugin to install in the container.
-
-Default: `1.2.0`
-
 ## uv-Specific Containerization Configurations
 
 **Example:** [Containerizing Dependencies with uv](../examples/uv/habushu-uv-containerize/README.md)
@@ -746,5 +741,10 @@ environments from a central location.
 
 Default: `true`
 
+### poetryMonorepoDependencyPluginVersion
+
+Specifies the specific version of the`poetry-monorepo-dependency-plugin` to be installed.
+
+Default: `latest`
 
 

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/PyenvAndPoetrySetup.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/PyenvAndPoetrySetup.java
@@ -39,6 +39,9 @@ public class PyenvAndPoetrySetup extends AbstractPythonPackageAndDependencyManag
      */
     private final File patchInstallScript;
 
+    private static final String poetryMonorepoDependencyPluginName = "poetry-monorepo-dependency-plugin";
+    private final String poetryMonorepoDependencyPluginVersion;
+
     /**
      * New instance - these values are typically passed in from Maven-enabled parameters in the calling Mojo.
      *
@@ -48,10 +51,11 @@ public class PyenvAndPoetrySetup extends AbstractPythonPackageAndDependencyManag
      */
     public PyenvAndPoetrySetup(String pythonVersion, boolean isPythonVersionConfigurationSet, String defaultPythonStrategy,
                                File baseDir, boolean rewriteLocalPathDepsInArchives, Log log, boolean usePyenv,
-                               File patchInstallScript) {
+                               File patchInstallScript, String poetryMonorepoDependencyPluginVersion) {
         super(pythonVersion, isPythonVersionConfigurationSet, defaultPythonStrategy, baseDir, rewriteLocalPathDepsInArchives, log);
         this.usePyenv = usePyenv;
         this.patchInstallScript = patchInstallScript;
+        this.poetryMonorepoDependencyPluginVersion = poetryMonorepoDependencyPluginVersion;
     }
 
     private List<String> validatePyenvInstallation(List<String> missingRequiredToolMsgs) {
@@ -251,7 +255,7 @@ public class PyenvAndPoetrySetup extends AbstractPythonPackageAndDependencyManag
     private void installPoetryMonorepoDependencyPlugin() {
         PoetryCommandHelper poetryHelper = createPoetryCommandHelper();
         log.info("Checking for updates to poetry-monorepo-dependency-plugin...");
-        poetryHelper.installPoetryPlugin("poetry-monorepo-dependency-plugin@latest");
+        poetryHelper.installPoetryPlugin(poetryMonorepoDependencyPluginName, poetryMonorepoDependencyPluginVersion);
     }
     
     /**

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/PythonPackageAndDependencyManagerFactory.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/PythonPackageAndDependencyManagerFactory.java
@@ -14,14 +14,14 @@ public class PythonPackageAndDependencyManagerFactory {
     public static PythonPackageAndDependencyManagerSetup createPythonPackageAndDependencyManagerSetup(
         String pythonVersion, boolean isPythonVersionConfigurationSet, String defaultPythonStrategy, File baseDir,
         boolean rewriteLocalPathDepsInArchives, Log log, PackageManager pythonPackageAndDependencyManager,
-        Boolean usePyenv, File patchInstallScript) {
+        Boolean usePyenv, File patchInstallScript, String poetryMonorepoDependencyPluginVersion) {
 
         if (pythonPackageAndDependencyManager == PackageManager.POETRY){
             if ((usePyenv == null) || (patchInstallScript == null)) {
                 throw new HabushuException("PyenvAndPoetrySetup requires usePyenv and patchInstallScript.");
             }
             return new PyenvAndPoetrySetup(pythonVersion, isPythonVersionConfigurationSet, defaultPythonStrategy, baseDir,
-                    rewriteLocalPathDepsInArchives, log, usePyenv, patchInstallScript);
+                    rewriteLocalPathDepsInArchives, log, usePyenv, patchInstallScript, poetryMonorepoDependencyPluginVersion);
         } else {
             return new UvSetup(pythonVersion, isPythonVersionConfigurationSet, defaultPythonStrategy, baseDir,
                     rewriteLocalPathDepsInArchives, log);

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/ValidatePythonPackageAndDependencyManagerMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/ValidatePythonPackageAndDependencyManagerMojo.java
@@ -59,6 +59,14 @@ public class ValidatePythonPackageAndDependencyManagerMojo extends AbstractHabus
     @Parameter(defaultValue = "${project.build.directory}/pyenv-patch-install-python-version.sh", readonly = true)
     private File patchInstallScript;
 
+    /**
+     * File specifying the location of a generated shell script that will attempt to
+     * install the specified version of Python using "pyenv install --patch" with a
+     * patch that attempts to resolve the expected compilation error.
+     */
+    @Parameter(defaultValue = "latest", property = "habushu.poetryMonorepoDependencyPluginVersion")
+    protected String poetryMonorepoDependencyPluginVersion;
+
     @Override
     public void doExecute() throws MojoExecutionException, MojoFailureException {
         PackageManager packageManager = HabushuUtil.checkPythonPackageManager(getPyProjectTomlFile());
@@ -80,7 +88,7 @@ public class ValidatePythonPackageAndDependencyManagerMojo extends AbstractHabus
         PythonPackageAndDependencyManagerSetup pythonPackageAndDependencyManagerSetup =
                 HabushuUtil.getPythonPackageAndDependencyManagerSetup(packageManager, pythonVersion, isPythonVersionConfigurationSet,
                         defaultPythonStrategy, getPythonProjectBaseDir(), rewriteLocalPathDepsInArchives, getLog(),
-                        usePyenv, patchInstallScript);
+                        usePyenv, patchInstallScript, poetryMonorepoDependencyPluginVersion);
 
         pythonPackageAndDependencyManagerSetup.execute();
 

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/exec/PoetryCommandHelper.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/exec/PoetryCommandHelper.java
@@ -5,7 +5,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+import com.vdurmont.semver4j.Semver;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -24,11 +27,13 @@ public class PoetryCommandHelper extends AbstractCommandHelper {
     private static final Logger logger = LoggerFactory.getLogger(PoetryCommandHelper.class);
 
     public static final String VERSION_DELIMITER = "@";
+    public static final String LATEST_VERSION = "latest";
     private static final int EXIT_SUCCESS = 0;
 
     private static final String EXTRACT_VERSION_REGEX = "[^0-9\\.]";
 
     protected volatile String showPluginsResult;
+    protected volatile String showOutdatedPluginsResult;
     protected static final Object pluginSystemLock = new Object();
 
 
@@ -106,47 +111,62 @@ public class PoetryCommandHelper extends AbstractCommandHelper {
      * double-checked locking execution of the `poetry self add <plugin>` call and avoidance of the add altogether if
      * the plugin already exists.
      *
-     * @param name name of the plugin to install
+     * @param pluginName name of the plugin to install
      * @return execution value
      */
-    public int installPoetryPlugin(String name) {
+    public int installPoetryPlugin(String pluginName, String pluginVersion) {
         int result = EXIT_SUCCESS;
-        if (pluginNeedsInstalling(name)) {
-            result = performInstallPoetryPlugin(name);
+        if (pluginNeedsInstalling(pluginName, pluginVersion)) {
+            result = performInstallPoetryPlugin(pluginName, pluginVersion);
         }
-
         return result;
     }
 
-    private int performInstallPoetryPlugin(String name) {
+    private int performInstallPoetryPlugin(String pluginName, String pluginVersion) {
         int result = EXIT_SUCCESS;
-
+        String pluginNameAndVersion = pluginName + VERSION_DELIMITER + pluginVersion;
         List<String> args = new ArrayList<>();
         args.add("self");
         args.add("add");
-        args.add(name);
+        args.add(pluginNameAndVersion);
         synchronized (pluginSystemLock) {
-            if (pluginNeedsInstalling(name)) {
+            if (pluginNeedsInstalling(pluginName, pluginVersion)) {
                 result = this.executeAndLogOutput(args);
 
                 // un-cache known set of plugins:
                 showPluginsResult = null;
+                showOutdatedPluginsResult = null;
             }
         }
 
         return result;
     }
 
-    private boolean pluginNeedsInstalling(String name) {
+    private boolean pluginNeedsInstalling(String pluginName, String pluginVersion) {
         executeShowPlugins();
 
-        String pluginNameWithoutVersion = name;
-        if (name.contains(VERSION_DELIMITER)) {
-            pluginNameWithoutVersion = pluginNameWithoutVersion.substring(0, name.indexOf(VERSION_DELIMITER));
-        }
+        boolean pluginInstalled = showPluginsResult.contains(pluginName);
 
-        return !showPluginsResult.contains(pluginNameWithoutVersion);
+        if (pluginInstalled) {
+            if (LATEST_VERSION.equals(pluginVersion)) {
+                executeShowOutdatedPlugins();
+                return showOutdatedPluginsResult.contains(pluginName);
+            } else {
+                String pluginRegex = "(?:" + pluginName + "\\s\\()(\\w+.*)(?:\\))";
+                Pattern pluginPattern = Pattern.compile(pluginRegex);
+                Matcher pluginVersionMatchedPattern = pluginPattern.matcher(showPluginsResult);
+                if (pluginVersionMatchedPattern.find()) {
+                    String currentPluginVersion = pluginVersionMatchedPattern.group(1);
+                    return !currentPluginVersion.equals(pluginVersion.trim());
+                }
+                // If we can't find the plugin version in the showPluginsResult, install the requested version to be safe.
+                return true;
+            }
+        } else {
+            return true;
+        }
     }
+
 
     private void executeShowPlugins() {
         if (StringUtils.isBlank(showPluginsResult)) {
@@ -166,6 +186,31 @@ public class PoetryCommandHelper extends AbstractCommandHelper {
                 synchronized (pluginSystemLock) {
                     if (StringUtils.isBlank(showPluginsResult)) {
                         showPluginsResult = this.execute(args);
+                    }
+                }
+
+            }
+        }
+    }
+
+    private void executeShowOutdatedPlugins() {
+        if (StringUtils.isBlank(showOutdatedPluginsResult)) {
+            List<String> args = new ArrayList<>();
+            args.add("self");
+            args.add("show");
+            args.add("--outdated");
+            try {
+                if (StringUtils.isBlank(showOutdatedPluginsResult)) {
+                    showOutdatedPluginsResult = this.execute(args);
+                }
+            } catch (HabushuException e) {
+                logger.info("Plugin status could not be determined. This is normally a race condition on another"
+                        + " thread touching poetry's underlying pyproject.toml, trying one more time...");
+                // let's be more careful round two and assume that there was a plugin being installed, so we need to
+                // respect that the lock could be engaged and synchronize on it to ensure ordered execution:
+                synchronized (pluginSystemLock) {
+                    if (StringUtils.isBlank(showOutdatedPluginsResult)) {
+                        showOutdatedPluginsResult = this.execute(args);
                     }
                 }
 

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/util/HabushuUtil.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/util/HabushuUtil.java
@@ -222,13 +222,14 @@ public final class HabushuUtil {
      * @param log
      * @param usePyenv
      * @param patchInstallScript
+     * @param poetryMonorepoDependencyPluginVersion
      * @return
      * @throws MojoExecutionException
      */
     public static PythonPackageAndDependencyManagerSetup getPythonPackageAndDependencyManagerSetup(
             PackageManager pythonPackageAndDependencyManager, String pythonVersion, boolean isPythonVersionConfigurationSet,
             String defaultPythonStrategy, File baseDir, boolean rewriteLocalPathDepsInArchives, Log log,
-            Boolean usePyenv, File patchInstallScript) {
+            Boolean usePyenv, File patchInstallScript, String poetryMonorepoDependencyPluginVersion) {
         // Set the poetry-based parameters to null
         if (pythonPackageAndDependencyManager == PackageManager.UV) {
             usePyenv = null;
@@ -237,7 +238,7 @@ public final class HabushuUtil {
 
         return PythonPackageAndDependencyManagerFactory.createPythonPackageAndDependencyManagerSetup(
                 pythonVersion, isPythonVersionConfigurationSet, defaultPythonStrategy, baseDir, rewriteLocalPathDepsInArchives, log,
-                pythonPackageAndDependencyManager, usePyenv, patchInstallScript);
+                pythonPackageAndDependencyManager, usePyenv, patchInstallScript, poetryMonorepoDependencyPluginVersion);
     }
 
     /**


### PR DESCRIPTION
#355 

*BLUF*

Within Habushu, we install the latest version of the `poetry-monorepo-dependency-plugin`. However, the installation logic does not include a check to see if the latest version of the plugin is installed. The purpose of this ticket is to add in a latest version check for the plugin. This functionality is internal to Habushu and not designed for end-user consumption. 