### PR TITLE
[#353] Update defaultPythonStrategy logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ dist/
 .idea/
 *.iml
 
+# VSCode
+.vscode/
+
 # Unit test reports
 TEST*.xml
 

--- a/docs/CONFIGURATION_README.md
+++ b/docs/CONFIGURATION_README.md
@@ -122,11 +122,11 @@ Default: `3.12.9`
 
 ### defaultPythonStrategy
 
-When `pythonVersion` is not explicitly specified, this strategy helps decide where to get the default version. If set to
-`PYTHONVERSION`, then Habushu will use the existing project's Python version. If set to `POM`, then Habushu will use
-the default value for `pythonVersion`.
+If set to `PYTHONVERSION`, then Habushu will use the Python version supplied in the `.python-version` file located in the project directory. If set to `POM`, then Habushu will use the default value for `pythonVersion`.
 
-Default: `PYTHONVERSION`
+**Note:** If set to `PYTHONVERSION` and no `.python-version` file is found in the project directory the build will fail with an error. 
+
+Default: `POM`
 
 **Example:** [Default Python Strategy](../examples/habushu-default-python-strategy/README.md)
 

--- a/examples/habushu-default-python-strategy/pom.xml
+++ b/examples/habushu-default-python-strategy/pom.xml
@@ -29,9 +29,9 @@
                 <configuration>
                     <!-- This will prevent the Habushu default python version from overriding the existing projects
                     version -->
-                    <defaultPythonStrategy>PYTHONVERSION</defaultPythonStrategy>
-                    <!-- This will tell Habushu to overriding the existing projects with the default Python version -->
-                    <!--<defaultPythonStrategy>POM</defaultPythonStrategy>-->
+                    <!-- <defaultPythonStrategy>PYTHONVERSION</defaultPythonStrategy> -->
+                    <!-- This will tell Habushu to override the existing projects with the default Python version -->
+                    <!-- <defaultPythonStrategy>POM</defaultPythonStrategy> -->
                 </configuration>
             </plugin>
         </plugins>

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/ValidatePythonPackageAndDependencyManagerMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/ValidatePythonPackageAndDependencyManagerMojo.java
@@ -8,6 +8,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.plexus.util.StringUtils;
+import org.technologybrewery.habushu.util.DefaultPythonStrategy;
 import org.technologybrewery.habushu.util.HabushuUtil;
 import org.technologybrewery.habushu.util.PackageManager;
 import org.technologybrewery.habushu.util.PoetryUtil;
@@ -41,7 +42,7 @@ public class ValidatePythonPackageAndDependencyManagerMojo extends AbstractHabus
     /**
      * The default python version strategy.
      */
-    @Parameter(defaultValue = "PYTHONVERSION", property = "habushu.defaultPythonStrategy")
+    @Parameter(defaultValue = "POM", property = "habushu.defaultPythonStrategy")
     protected String defaultPythonStrategy;
 
     /**
@@ -62,8 +63,15 @@ public class ValidatePythonPackageAndDependencyManagerMojo extends AbstractHabus
     public void doExecute() throws MojoExecutionException, MojoFailureException {
         PackageManager packageManager = HabushuUtil.checkPythonPackageManager(getPyProjectTomlFile());
         boolean isPythonVersionConfigurationSet = true;
-
-        // If pythonVersion was not given then update isPythonVersionConfigurationSet and set it to the default
+        boolean isPythonVersionFilePresent = HabushuUtil.validatePythonVersionFile(getPythonProjectBaseDir());
+        
+        // If the defaultPythonStrategy is set to PYTHONVERSION, then we need to check if the .python-version file is present
+        if (DefaultPythonStrategy.PYTHONVERSION.name().equalsIgnoreCase(defaultPythonStrategy) &&
+            !isPythonVersionFilePresent) {
+            throw new MojoExecutionException("defaultPythonStrategy is set to PYTHONVERSION, but no .python-version file was found in the project directory.");
+        }
+        
+         // If pythonVersion was not given then update isPythonVersionConfigurationSet and set it to the default
         if (StringUtils.isEmpty(pythonVersion)) {
             isPythonVersionConfigurationSet = false;
             pythonVersion = HabushuUtil.PYTHON_DEFAULT_VERSION_REQUIREMENT;

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/util/HabushuUtil.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/util/HabushuUtil.java
@@ -374,4 +374,15 @@ public final class HabushuUtil {
         return inputUrl;
     }
 
+    /**
+     * Validates the existence of the .python-version file.
+     *
+     * @param baseDir the base directory of the project
+     * @return true if .python-version file exists in the project directory.
+     */
+    public static boolean validatePythonVersionFile(File baseDir) {
+        File pythonVersionFile = new File(baseDir, ".python-version");
+        return pythonVersionFile.exists();
+    }
+
 }


### PR DESCRIPTION
Ref: #353

Updating `defaultPythonStrategy` so that `POM` will be the `defaultPythonStrategy` and when users manually change `defaultPythonStrategy` to `PYTHONVERSION` and there is no `.python-version` file, habushu will now error out with a clear message instead of defaulting to `3.12.9`.