### PR TITLE
[#354] Poetry v2 Migration - remove empty section headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ This update introduces a number of migrations that ensure configurations are mor
 - `PoetryToProjectRequiresPythonMigration`: Relocates the Python dependency from `[tool.poetry.dependencies]` to the `requires-python` entry under `[project]`
 - `PoetryToProjectDynamicMigration`: Introduces a `dynamic` field under `[project]` that automatically includes `version` and `dependency`, if not already present. If a single `readme` (as a string) is included in `[tool.poetry]`, then migrates it from `[tool.poetry]` to `[project]`. If multiple `readme` values are defined (as a table) in `[tool.poetry]`, `readme` is added to the `dynamic` field list.
 - `PoetryTomlMigration`: Removes deprecated configurations from the `poetry.toml` file
+- `PoetryRemoveEmptyTomlMigration`: Removes any empty `[tool.poetry]` and `[tool.poetry.dependencies]` headers from `pyproject.toml`
 
 **Note:** Baton migrations are forward compatible only. If you upgrade to Poetry v2.0+ and later decide to downgrade, you will need to manually revert the changes in your TOML files.
 

--- a/examples/habushu-default-python-strategy/pyproject.toml
+++ b/examples/habushu-default-python-strategy/pyproject.toml
@@ -1,5 +1,3 @@
-[tool.poetry]
-
 [project]
 name = "habushu_default_python_strategy"
 version = "3.0.0.dev"
@@ -8,8 +6,6 @@ authors = [{name = "Ryan Ashcraft", email = "ryan.ashcraft@codifyiq.com"}]
 license = "MIT License"
 requires-python = ">=3.12"
 dynamic = ["version", "dependencies"]
-
-[tool.poetry.dependencies]
 
 [tool.poetry.group.dev.dependencies]
 behave = ">=1.2.6"

--- a/examples/habushu-managed-dependencies/pyproject.toml
+++ b/examples/habushu-managed-dependencies/pyproject.toml
@@ -1,5 +1,3 @@
-[tool.poetry]
-
 [project]
 name = "habushu_managed_dependencies"
 version = "3.0.0.dev"
@@ -8,8 +6,6 @@ authors = [{name = "Ryan Ashcraft", email = "ryan.ashcraft@codifyiq.com"}]
 license = "MIT License"
 requires-python = ">=3.12"
 dynamic = ["version", "dependencies"]
-
-[tool.poetry.dependencies]
 
 [tool.poetry.group.dev.dependencies]
 behave = ">=1.2.6"

--- a/examples/habushu-running-python-scripts/pyproject.toml
+++ b/examples/habushu-running-python-scripts/pyproject.toml
@@ -1,5 +1,3 @@
-[tool.poetry]
-
 [project]
 name = "habushu_running_python_scripts"
 version = "3.0.0.dev"

--- a/examples/poetry/habushu-poetry-containerize/pyproject.toml
+++ b/examples/poetry/habushu-poetry-containerize/pyproject.toml
@@ -7,8 +7,6 @@ license = "MIT License"
 requires-python = ">=3.12"
 dynamic = ["version", "dependencies"]
 
-[tool.poetry.dependencies]
-
 [tool.poetry.group.dev.dependencies]
 ruff = ">=0.9.9"
 

--- a/examples/poetry/habushu-poetry-package-consumer/pyproject.toml
+++ b/examples/poetry/habushu-poetry-package-consumer/pyproject.toml
@@ -1,5 +1,3 @@
-[tool.poetry]
-
 [project]
 name = "habushu_poetry_package_consumer"
 version = "3.0.0.dev"

--- a/examples/poetry/habushu-poetry-package/pyproject.toml
+++ b/examples/poetry/habushu-poetry-package/pyproject.toml
@@ -1,5 +1,3 @@
-[tool.poetry]
-
 [project]
 name = "habushu_poetry_package"
 version = "3.0.0.dev"

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryRemoveEmptyTomlMigration.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryRemoveEmptyTomlMigration.java
@@ -1,0 +1,115 @@
+package org.technologybrewery.habushu.migration.poetryv2migrations;
+
+import com.electronwill.nightconfig.core.Config;
+import com.electronwill.nightconfig.core.file.FileConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.technologybrewery.baton.BatonException;
+import org.technologybrewery.habushu.util.TomlUtils;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Provides functionality to remove empty headers from pyproject.toml file
+ * Runs when on Poetry v2.0.0 or later.
+ */
+public class PoetryRemoveEmptyTomlMigration extends AbstractPoetryMigration{
+    private static final Logger logger = LoggerFactory.getLogger(PoetryRemoveEmptyTomlMigration.class);
+    private boolean isToolPoetryEmpty;
+    private boolean isToolPoetryDepsEmpty;
+
+    @Override
+    protected boolean shouldExecuteOnFile(File file) {
+        if (isPoetryProject(file) && isPoetryVersionAtLeast2){
+            try(FileConfig tomlFileConfig = FileConfig.of(file)){
+                tomlFileConfig.load();
+                List<String> allTomlSectionHeaders = TomlUtils.extractTomlSectionHeaders(file);
+
+                Optional<Config> toolPoetryGroupOpt = tomlFileConfig.getOptional(TomlUtils.TOOL_POETRY);
+                boolean hasToolPoetryHeader = allTomlSectionHeaders.contains(TomlUtils.TOOL_POETRY);
+
+                // only check for emptiness if the header actually exists
+                if (hasToolPoetryHeader && toolPoetryGroupOpt.isPresent()){
+                    isToolPoetryEmpty = TomlUtils.isSectionEmpty(toolPoetryGroupOpt.get(), TomlUtils.TOOL_POETRY, allTomlSectionHeaders);
+                }
+
+                Optional<Config> toolPoetryDepsGroupOpt = tomlFileConfig.getOptional(TomlUtils.TOOL_POETRY_DEPENDENCIES);
+                boolean hasToolPoetryDepsHeader = allTomlSectionHeaders.contains(TomlUtils.TOOL_POETRY_DEPENDENCIES);
+
+                if (hasToolPoetryDepsHeader && toolPoetryDepsGroupOpt.isPresent()) {
+                    isToolPoetryDepsEmpty = TomlUtils.isSectionEmpty(toolPoetryDepsGroupOpt.get(), TomlUtils.TOOL_POETRY_DEPENDENCIES, allTomlSectionHeaders);
+                }
+            }
+        }
+        return isToolPoetryEmpty || isToolPoetryDepsEmpty;
+    }
+
+
+
+    @Override
+    protected boolean performMigration(File pyProjectTomlFile) {
+        boolean inToolPoetrySection = false;
+        boolean inToolPoetryDepsSection = false;
+        StringBuilder fileContent = new StringBuilder();
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(pyProjectTomlFile))) {
+            String line = reader.readLine();
+            while (line != null) {
+                boolean addLine = true;
+                String trimmedLine = line.strip();
+
+                if (trimmedLine.startsWith("[") && trimmedLine.endsWith("]")){
+                    if (trimmedLine.equals("[" + TomlUtils.TOOL_POETRY +"]")) {
+                        inToolPoetrySection = true;
+                        inToolPoetryDepsSection = false;
+                        if(isToolPoetryEmpty){
+                            logger.info("Removing empty [tool.poetry] header...");
+                            addLine = false;
+                        }
+                    } else if (trimmedLine.equals("[" + TomlUtils.TOOL_POETRY_DEPENDENCIES +"]")){
+                        inToolPoetrySection = false;
+                        inToolPoetryDepsSection = true;
+                        if (isToolPoetryDepsEmpty){
+                            logger.info("Removing empty [tool.poetry.dependencies] header...");
+                            addLine = false;
+                        }
+                    } else {
+                        inToolPoetrySection = false;
+                        inToolPoetryDepsSection = false;
+                    }
+                } else if (trimmedLine.isEmpty()){
+                    // remove any blank lines following empty section headers
+                    if (inToolPoetrySection && isToolPoetryEmpty){
+                        addLine = false;
+                        inToolPoetrySection = false;
+                    } else if (inToolPoetryDepsSection && isToolPoetryDepsEmpty){
+                        addLine = false;
+                        inToolPoetryDepsSection = false;
+                    }
+                }
+
+                if (addLine) {
+                    fileContent.append(line).append("\n");
+                }
+
+                line = reader.readLine();
+            }
+
+        } catch (IOException e) {
+            throw new BatonException("Problem reading pyproject.toml for migration!", e);
+        }
+
+        try {
+            TomlUtils.writeTomlFile(pyProjectTomlFile, fileContent.toString());
+        } catch (IOException e) {
+            throw new BatonException("Problem writing updated pyproject.toml!", e);
+        }
+
+        return true;
+    }
+}

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/util/TomlUtils.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/util/TomlUtils.java
@@ -1,12 +1,17 @@
 package org.technologybrewery.habushu.util;
 
 import com.electronwill.nightconfig.core.CommentedConfig;
+import com.electronwill.nightconfig.core.Config;
 import org.apache.commons.collections4.CollectionUtils;
+import org.technologybrewery.baton.BatonException;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
+import java.util.ArrayList;
 import java.util.List;
 
 import java.util.regex.Matcher;
@@ -16,7 +21,6 @@ import java.util.regex.Pattern;
  * Common utility methods for handling TOML files.
  */
 public final class TomlUtils {
-
     public static final String EQUALS = "=";
     public static final String DOUBLE_QUOTE = "\"";
     public static final String TOOL_POETRY = "tool.poetry";
@@ -69,6 +73,13 @@ public final class TomlUtils {
      * The regex captures <operator> (package-a) and <version> (>=2.0.0) as separate groups named "operator" and "version"
      */
     private static final String OPERATOR_AND_VERSION_REGEX = "^(?<operator>[><=]+)(?<version>\\d+(?:\\.\\d+)?(?:\\.\\d+)?)$";
+
+    /**
+     * Matches a TOML section header line (single or nested),
+     * e.g. "[a.b]" or "[[a.b]]", capturing the text between the brackets
+     * as group 1 (the full section name without surrounding '[' or ']').
+     */
+    private static final String TOML_SECTION_HEADER_REGEX = "^\\[+(.+?)\\]+$";
 
 
     protected TomlUtils() {
@@ -374,6 +385,84 @@ public final class TomlUtils {
      */
     public static boolean hasComparators(String string) {
         return COMPARATORS.stream().anyMatch(string::contains);
+    }
+
+    /**
+     * Reads a TOML file and extracts every section header (the text between '[' and ']').
+     *
+     * @param file  the TOML file to scan
+     * @return      a list of section names without surrounding brackets
+     */
+    public static List<String> extractTomlSectionHeaders(File file){
+        Pattern headerPattern = Pattern.compile(TOML_SECTION_HEADER_REGEX);
+        List<String> sectionHeadersList = new ArrayList<>();
+        try(BufferedReader reader = new BufferedReader(new FileReader(file))){
+            String line = reader.readLine();
+            while (line != null){
+                Matcher m = headerPattern.matcher(line.strip());
+                if (m.matches()) {
+                    sectionHeadersList.add(m.group(1));
+                }
+                line = reader.readLine();
+            }
+        } catch (IOException e){
+            throw new BatonException("Error while extracting section headers from pyproject.toml file!", e);
+        }
+        return sectionHeadersList;
+    }
+
+    /**
+     * Returns the list of keys in the given TOML section whose values
+     * are themselves nested Config tables (i.e. subsections).
+     *
+     * @param section  the Config representing a TOML table
+     * @return         a list of keys whose associated values are Config instances
+     */
+    public static List<String> getConfigKeys(Config section){
+        List<String> configKeys = new ArrayList<>();
+        for (Config.Entry entry : section.entrySet()){
+            if (entry.getValue() instanceof Config){
+                configKeys.add(entry.getKey());
+            }
+        }
+        return configKeys;
+    }
+
+    /**
+     * Determines whether a TOML section contains no direct key–value entries
+     * and no inline tables, i.e. it only consists of subtables that each
+     * have their own explicit headers.
+     *
+     * @param sectionConfig      the Config representing the TOML section to check
+     * @param parentHeaderName  the full section name used to match headers
+     *                          in allTomlSectionHeaders (e.g. "tool.poetry")
+     * @param allTomlHeaders    list of all section headers in the file (strings between '[' and ']')
+     * @return                   {@code true} if the section has neither literal
+     *                          values nor inline tables; {@code false} otherwise
+     */
+
+    public static boolean isSectionEmpty(Config sectionConfig, String parentHeaderName, List<String> allTomlHeaders){
+        // extract the names of any nested Configs under parent section
+        List<String> childConfigKeys = getConfigKeys(sectionConfig);
+
+        // if there are any literal values (i.e. non-Config entries), the parent section is not empty
+        if (sectionConfig.entrySet().size() != childConfigKeys.size()){
+            return false;
+        }
+
+        // for each nested Config, check if there is a corresponding exact or nested header
+        for (String key : childConfigKeys){
+            String prefix = parentHeaderName + "." + key;
+            // e.g., if parentHeaderName = tool.poetry & key = dependencies,
+            // returns true if [tool.poetry.dependencies] (exact) or [tool.poetry.dependencies.group] (nested) exists
+            boolean headerExists = allTomlHeaders.stream().anyMatch(header -> header.equals(prefix) || header.startsWith(prefix + "."));
+
+            if (!headerExists){
+                // no matching header means this was an inline table and parent section is not empty
+                return false;
+            }
+        }
+        return true;
     }
 
 }

--- a/habushu-maven-plugin/src/main/resources/migrations.json
+++ b/habushu-maven-plugin/src/main/resources/migrations.json
@@ -79,6 +79,20 @@
             ]
           }
         ]
+      },
+      {
+        "name": "poetry-v2-remove-empty-toml-migration",
+        "implementation": "org.technologybrewery.habushu.migration.poetryv2migrations.PoetryRemoveEmptyTomlMigration",
+        "fileSets": [
+          {
+            "includes": [
+              "pyproject.toml"
+            ],
+            "excludes": [
+              "**/examples/poetry/habushu-poetry-install-from-dev-repo/pyproject.toml"
+            ]
+          }
+        ]
       }
     ]
   }

--- a/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/migration/poetryv2migrations/AbstractPoetryMigrationSteps.java
+++ b/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/migration/poetryv2migrations/AbstractPoetryMigrationSteps.java
@@ -2,32 +2,25 @@ package org.technologybrewery.habushu.migration.poetryv2migrations;
 
 import com.electronwill.nightconfig.core.Config;
 import com.electronwill.nightconfig.core.file.FileConfig;
-import org.technologybrewery.habushu.util.TomlUtils;
 
 import java.io.File;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+
+/**
+ * Pure helper methods for loading TOML groups and making assertions.
+ * All methods take explicit File + section/key arguments—no static fields.
+ */
 public class AbstractPoetryMigrationSteps{
     protected static File testTomlFileDirectory = new File("./target/test-classes/migration/poetry-v2");
     protected static File pyProjectToml;
-    protected Optional<Config> projectOpt;
-    protected Optional<Config> toolPoetryOpt;
-    protected Optional<Config> toolPoetryDependenciesOpt;
-    protected Optional<Config> virtualEnvsOpt;
-    protected Optional<Config> experimentalOpt;
-    protected Config projectEntries;
-    protected Config toolPoetryEntries;
-    protected Config toolPoetryDependencyEntries;
-    protected Config virtualEnvsEntries;
-    protected Config experimentalEntries;
-    protected boolean shouldExecute;
-    protected boolean executionSucceeded;
 
-    protected void verifyExecutionOccurred() {
+    protected void verifyExecutionOccurred(boolean shouldExecute, boolean executionSucceeded) {
         assertTrue(shouldExecute, "Migration should have been selected to execute!");
         assertTrue(executionSucceeded, "Migration should have executed successfully!");
     }
@@ -46,66 +39,43 @@ public class AbstractPoetryMigrationSteps{
     /**
      * Helper method to check if entry exists within specified toml group
      */
-    protected void assertKeyExists(String groupName, String key, boolean shouldExist) {
-        loadAndAssertGroupExists(groupName);
-
-        // Retrieve the appropriate entries based on groupName
-        Config entries;
-        if (groupName.equals(TomlUtils.PROJECT)) {
-            entries = projectEntries;
-        } else if (groupName.equals(TomlUtils.TOOL_POETRY)) {
-            entries = toolPoetryEntries;
-        } else if (groupName.equals(TomlUtils.TOOL_POETRY_DEPENDENCIES)) {
-            entries = toolPoetryDependencyEntries;
-        } else if (groupName.equals(TomlUtils.EXPERIMENTAL)) {
-            entries = experimentalEntries;
-        } else {
-            throw new IllegalArgumentException("Unknown group: " + groupName);
-        }
-
+    protected void assertKeyExists(Config groupEntries, String key, boolean shouldExist) {
         if (shouldExist) {
-            assertTrue(entries.contains(key), key + " should exist under " + groupName);
+            assertTrue(groupEntries.contains(key), key + " should exist in group");
         } else {
-            assertFalse(entries.contains(key), key + " should NOT exist under " + groupName);
+            assertFalse(groupEntries.contains(key), key + " should NOT exist in group");
         }
     }
 
     /**
-     * Helper methods to load a toml group and assert its presence
+     * Helper methods to load a toml group and/or assert its presence
      */
-    protected void loadAndAssertGroupExists(String groupName) {
+    protected Config loadAndAssertGroupExists(String groupName){
         Optional<Config> groupOpt = getOptionalConfig(pyProjectToml, groupName);
         assertTrue(groupOpt.isPresent(), groupName + " missing from toml file");
-        Config entries = groupOpt.get();
-
-        if (groupName.equals(TomlUtils.PROJECT)) {
-            projectOpt = groupOpt;
-            projectEntries = entries;
-        } else if (groupName.equals(TomlUtils.TOOL_POETRY)) {
-            toolPoetryOpt = groupOpt;
-            toolPoetryEntries = entries;
-        } else if (groupName.equals(TomlUtils.TOOL_POETRY_DEPENDENCIES)) {
-            toolPoetryDependenciesOpt = groupOpt;
-            toolPoetryDependencyEntries = entries;
-        } else if (groupName.equals(TomlUtils.VIRTUAL_ENVS)){
-            virtualEnvsOpt = groupOpt;
-            virtualEnvsEntries = entries;
-        } else if (groupName.equals(TomlUtils.EXPERIMENTAL)){
-            experimentalOpt = groupOpt;
-            experimentalEntries = entries;
-        } else {
-            throw new IllegalArgumentException("Unknown group: " + groupName);
-        }
+        return groupOpt.get();
     }
 
-    protected void loadAndAssertDoesNotExist(String groupName) {
+    protected void assertGroupExists(String groupName){
         Optional<Config> groupOpt = getOptionalConfig(pyProjectToml, groupName);
-        assertFalse(groupOpt.isPresent(), groupName + " missing from toml file");
+        assertTrue(groupOpt.isPresent(), groupName + " missing from toml file");
     }
 
-    protected void assertNumOfEntries(Config group, Integer expectedExperimentalEntries ){
-        int actualEntries = getNumberOfEntries(group);
-        assertEquals(expectedExperimentalEntries, actualEntries, expectedExperimentalEntries + " entries should remain in the group!");
+    protected void assertGroupDoesNotExist(String groupName){
+        Optional<Config> groupOpt = getOptionalConfig(pyProjectToml, groupName);
+        assertFalse(groupOpt.isPresent(), groupName + " should not be in toml file");
     }
 
+    protected void assertNumOfEntries(Config groupName, Integer expectedExperimentalEntries ){
+        int actualNumEntries = getNumberOfEntries(groupName);
+        assertEquals(expectedExperimentalEntries, actualNumEntries, expectedExperimentalEntries + " entries should remain in the group!");
+    }
+
+    /**
+     * Helper method to check if header (as "[sectionName]" string) exists in a toml file
+     */
+    protected boolean isSectionHeaderMissing(List<String> allHeaders, String sectionName) {
+        return allHeaders.stream()
+                .noneMatch(header -> header.equals(sectionName));
+    }
 }

--- a/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryRemoveEmptyTomlMigrationSteps.java
+++ b/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryRemoveEmptyTomlMigrationSteps.java
@@ -1,0 +1,95 @@
+package org.technologybrewery.habushu.migration.poetryv2migrations;
+
+import com.electronwill.nightconfig.core.Config;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.technologybrewery.habushu.util.TomlUtils;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class PoetryRemoveEmptyTomlMigrationSteps extends AbstractPoetryMigrationSteps {
+    private boolean shouldExecute;
+    private boolean executionSucceeded;
+    private List<String> allTomlSectionHeaders = new ArrayList<>();
+
+    @Given("an existing pyproject.toml file with no direct entries under the tool.poetry header")
+    public void an_existing_pyproject_toml_file_with_no_entries_under_the_tool_poetry_header() {
+        pyProjectToml = new File(testTomlFileDirectory, "with-no-entries-under-tool-poetry.toml");
+        Config toolPoetryEntries = loadAndAssertGroupExists(TomlUtils.TOOL_POETRY);
+        assertNumOfEntries(toolPoetryEntries, 2);
+    }
+
+    @Given("an existing pyproject.toml file with no direct entries under the tool.poetry.dependencies header")
+    public void an_existing_pyproject_toml_file_with_no_entries_under_the_tool_poetry_dependencies_header() {
+        pyProjectToml = new File(testTomlFileDirectory, "with-no-entries-under-tool-poetry-dependencies.toml");
+        Config toolPoetryDepsEntries = loadAndAssertGroupExists(TomlUtils.TOOL_POETRY_DEPENDENCIES);
+        assertNumOfEntries(toolPoetryDepsEntries, 0);
+    }
+
+    @Given("an existing pyproject.toml file with no direct entries under the tool.poetry and tool.poetry.dependencies headers")
+    public void an_existing_pyproject_toml_file_with_no_entries_under_the_tool_poetry_and_tool_poetry_dependencies_header() {
+        pyProjectToml = new File(testTomlFileDirectory, "with-no-entries-under-tool-poetry-and-tool-poetry-dependencies.toml");
+        Config toolPoetryEntries = loadAndAssertGroupExists(TomlUtils.TOOL_POETRY);
+        Config toolPoetryDepsEntries = loadAndAssertGroupExists(TomlUtils.TOOL_POETRY_DEPENDENCIES);
+        assertNumOfEntries(toolPoetryEntries, 2);
+        assertNumOfEntries(toolPoetryDepsEntries, 0);
+    }
+
+    @Given("an existing pyproject.toml file with an inline dependencies table under the tool.poetry header")
+    public void an_existing_pyproject_toml_file_with_inline_deps_table_under_tool_poetry_header(){
+        pyProjectToml = new File(testTomlFileDirectory, "with-inline-deps-table-under-tool-poetry.toml");
+        Config toolPoetryEntries = loadAndAssertGroupExists(TomlUtils.TOOL_POETRY);
+        assertNumOfEntries(toolPoetryEntries, 2);
+    }
+
+    @When("the Habushu poetry-remove-empty-toml migration executes")
+    public void the_habushu_poetry_remove_empty_toml_migration_executes() {
+        PoetryRemoveEmptyTomlMigration migration = new PoetryRemoveEmptyTomlMigration();
+        migration.setWorkingDirectory(new File("."));
+        migration.setIsPoetryVersionAtLeast2(PoetryV2MigrationContext.getIsPoetryAtLeast2());
+
+        shouldExecute = migration.shouldExecuteOnFile(pyProjectToml);
+        executionSucceeded = (shouldExecute) ? migration.performMigration(pyProjectToml) : false;
+    }
+
+    @Then("the tool.poetry header is removed")
+    public void the_tool_poetry_header_is_removed(){
+        verifyExecutionOccurred(shouldExecute, executionSucceeded);
+        allTomlSectionHeaders = TomlUtils.extractTomlSectionHeaders(pyProjectToml);
+        assertTrue(isSectionHeaderMissing(allTomlSectionHeaders, TomlUtils.TOOL_POETRY));
+    }
+
+    @Then("the tool.poetry.dependencies header is removed")
+    public void the_tool_poetry_deps_header_is_removed(){
+        verifyExecutionOccurred(shouldExecute, executionSucceeded);
+        allTomlSectionHeaders = TomlUtils.extractTomlSectionHeaders(pyProjectToml);
+        assertTrue(isSectionHeaderMissing(allTomlSectionHeaders, TomlUtils.TOOL_POETRY_DEPENDENCIES));
+    }
+
+    @Then("the tool.poetry and tool.poetry.dependencies headers are removed")
+    public void the_tool_poetry_header_and_tool_poetry_deps__header_are_removed(){
+        verifyExecutionOccurred(shouldExecute, executionSucceeded);
+        allTomlSectionHeaders = TomlUtils.extractTomlSectionHeaders(pyProjectToml);
+        assertTrue(isSectionHeaderMissing(allTomlSectionHeaders, TomlUtils.TOOL_POETRY));
+        assertTrue(isSectionHeaderMissing(allTomlSectionHeaders, TomlUtils.TOOL_POETRY_DEPENDENCIES));
+    }
+
+    @Then("the tool.poetry header is not removed")
+    public void the_tool_poetry_header_is_not_removed(){
+        assertFalse(shouldExecute, "Migration execution should have been skipped!");        allTomlSectionHeaders = TomlUtils.extractTomlSectionHeaders(pyProjectToml);
+        assertFalse(isSectionHeaderMissing(allTomlSectionHeaders, TomlUtils.TOOL_POETRY));
+    }
+
+    @Then("the poetry-remove-empty-toml migration did not execute")
+    public void the_poetry_remove_empty_toml_migration_did_not_execute() {
+        assertFalse(shouldExecute, "Migration execution should have been skipped!");
+    }
+
+}
+

--- a/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryToProjectDynamicMigrationSteps.java
+++ b/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryToProjectDynamicMigrationSteps.java
@@ -1,10 +1,11 @@
 package org.technologybrewery.habushu.migration.poetryv2migrations;
 
+import com.electronwill.nightconfig.core.Config;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import org.technologybrewery.habushu.PoetryCommandHelperTestWrapper;
+
 import org.technologybrewery.habushu.util.TomlUtils;
 
 import java.io.File;
@@ -12,41 +13,27 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 public class PoetryToProjectDynamicMigrationSteps extends AbstractPoetryMigrationSteps {
-    private PoetryCommandHelperTestWrapper poetryHelper;
-    private boolean mockIsPoetryVersionAtLeast2;
-
-    @Given("Poetry version at least \"2.0.0\"")
-    public void poetry_version_at_least_2_0_0(){
-        poetryHelper = new PoetryCommandHelperTestWrapper(new File("."), "2.0.0");
-        mockIsPoetryVersionAtLeast2 = poetryHelper.isPoetryVersionAtLeastMinimumVersion();
-        assertTrue(mockIsPoetryVersionAtLeast2, "The Poetry version found was less than 2.0.0");
-    }
-
-    @Given("Poetry version less than \"2.0.0\"")
-    public void poetry_version_less_than_2_0_0(){
-        poetryHelper = new PoetryCommandHelperTestWrapper(new File("."), "1.6.1");
-        mockIsPoetryVersionAtLeast2 = poetryHelper.isPoetryVersionAtLeastMinimumVersion();
-        assertFalse(mockIsPoetryVersionAtLeast2, "The Poetry version found greater than 2.0.0");
-    }
+    private boolean shouldExecute;
+    private boolean executionSucceeded;
 
     @Given("an existing pyproject.toml file with no dynamic in project and no readme in tool.poetry")
     public void an_existing_pyproject_toml_file_with_no_dynamic_in_project_and_no_readme_in_tool_poetry() {
         pyProjectToml = new File(testTomlFileDirectory, "with-no-dynamic-in-project-and-no-readme-in-tool-poetry.toml");
-
-        assertKeyExists(TomlUtils.PROJECT, TomlUtils.DYNAMIC, false);
-        assertKeyExists(TomlUtils.TOOL_POETRY, TomlUtils.README, false);
+        Config projectEntries = loadAndAssertGroupExists(TomlUtils.PROJECT);
+        Config toolPoetryEntries = loadAndAssertGroupExists(TomlUtils.TOOL_POETRY);
+        assertKeyExists(projectEntries, TomlUtils.DYNAMIC, false);
+        assertKeyExists(toolPoetryEntries, TomlUtils.README, false);
     }
 
     @When("the Habushu poetry-to-project-dynamic migration executes")
     public void the_habushu_poetry_to_project_dynamic_migration_executes() {
         PoetryToProjectDynamicMigration migration = new PoetryToProjectDynamicMigration();
         migration.setWorkingDirectory(new File("."));
-        migration.setIsPoetryVersionAtLeast2(mockIsPoetryVersionAtLeast2);
+        migration.setIsPoetryVersionAtLeast2(PoetryV2MigrationContext.getIsPoetryAtLeast2());
 
         shouldExecute = migration.shouldExecuteOnFile(pyProjectToml);
         executionSucceeded = (shouldExecute) ? migration.performMigration(pyProjectToml) : false;
@@ -54,9 +41,9 @@ public class PoetryToProjectDynamicMigrationSteps extends AbstractPoetryMigratio
 
     @Then("the dynamic entry is added to the project group and contains")
     public void the_dynamic_entry_with_readme_is_added_in_the_project_group_and_contains(DataTable dataTable) {
-        verifyExecutionOccurred();
-
-        assertKeyExists(TomlUtils.PROJECT, TomlUtils.DYNAMIC, true);
+        verifyExecutionOccurred(shouldExecute, executionSucceeded);
+        Config projectEntries = loadAndAssertGroupExists(TomlUtils.PROJECT);
+        assertKeyExists(projectEntries, TomlUtils.DYNAMIC, true);
 
         List<String> expectedEntries = dataTable.asList(String.class);
         Object actualEntries = projectEntries.get(TomlUtils.DYNAMIC);
@@ -66,9 +53,10 @@ public class PoetryToProjectDynamicMigrationSteps extends AbstractPoetryMigratio
     @Given("an existing pyproject.toml file with no dynamic in project and with a single readme in tool.poetry")
     public void an_existing_pyproject_toml_file_with_no_dynamic_in_project_and_with_a_single_readme_in_tool_poetry() {
         pyProjectToml = new File(testTomlFileDirectory, "with-no-dynamic-in-project-and-with-single-readme-in-tool-poetry.toml");
-
-        assertKeyExists(TomlUtils.PROJECT, TomlUtils.DYNAMIC, false);
-        assertKeyExists(TomlUtils.TOOL_POETRY, TomlUtils.README, true);
+        Config projectEntries = loadAndAssertGroupExists(TomlUtils.PROJECT);
+        Config toolPoetryEntries = loadAndAssertGroupExists(TomlUtils.TOOL_POETRY);
+        assertKeyExists(projectEntries, TomlUtils.DYNAMIC, false);
+        assertKeyExists(toolPoetryEntries, TomlUtils.README, true);
 
         Object readMeEntry = toolPoetryEntries.get(TomlUtils.README);
         assertInstanceOf(String.class, readMeEntry, "[tool.poetry] readme does not contain single string value as expected");
@@ -76,21 +64,24 @@ public class PoetryToProjectDynamicMigrationSteps extends AbstractPoetryMigratio
 
     @Then("the readme entry is added to the project group as {string}")
     public void the_readme_entry_is_added_in_the_project_group(String expectedReadMeEntry) {
-        assertKeyExists(TomlUtils.PROJECT, TomlUtils.README, true);
+        Config projectEntries = loadAndAssertGroupExists(TomlUtils.PROJECT);
+        assertKeyExists(projectEntries, TomlUtils.README, true);
         assertEquals(expectedReadMeEntry, projectEntries.get(TomlUtils.README).toString(), "readme was set incorrectly in [project]");
     }
 
     @Then("the readme entry is removed from the tool.poetry group")
     public void the_readme_entry_is_removed_from_the_tool_poetry_group() {
-        assertKeyExists(TomlUtils.TOOL_POETRY, TomlUtils.README, false);
+        Config toolPoetryEntries = loadAndAssertGroupExists(TomlUtils.TOOL_POETRY);
+        assertKeyExists(toolPoetryEntries, TomlUtils.README, false);
     }
 
     @Given("an existing pyproject.toml file with no dynamic in project and with multiple readmes in tool.poetry")
     public void an_existing_pyproject_toml_file_with_no_dynamic_in_project_and_multiple_readmes_in_tool_poetry() {
         pyProjectToml = new File(testTomlFileDirectory, "with-no-dynamic-in-project-and-with-multiple-readmes-in-tool-poetry.toml");
-
-        assertKeyExists(TomlUtils.PROJECT, TomlUtils.DYNAMIC, false);
-        assertKeyExists(TomlUtils.TOOL_POETRY, TomlUtils.README, true);
+        Config projectEntries = loadAndAssertGroupExists(TomlUtils.PROJECT);
+        Config toolPoetryEntries = loadAndAssertGroupExists(TomlUtils.TOOL_POETRY);
+        assertKeyExists(projectEntries, TomlUtils.DYNAMIC, false);
+        assertKeyExists(toolPoetryEntries, TomlUtils.README, true);
 
         Object readMeEntries = toolPoetryEntries.get(TomlUtils.README);
         assertInstanceOf(ArrayList.class, readMeEntries, "[tool.poetry] readme does not contain multiple values as expected");
@@ -98,7 +89,8 @@ public class PoetryToProjectDynamicMigrationSteps extends AbstractPoetryMigratio
 
     @Then("the readme entry remains in the tool.poetry group and contains")
     public void the_readme_entry_remains_in_the_tool_poetry_group_and_contains(DataTable dataTable) {
-        assertKeyExists(TomlUtils.TOOL_POETRY, TomlUtils.README, true);
+        Config toolPoetryEntries = loadAndAssertGroupExists(TomlUtils.TOOL_POETRY);
+        assertKeyExists(toolPoetryEntries, TomlUtils.README, true);
 
         List<String> expectedEntries = dataTable.asList(String.class);
         Object actualEntries = toolPoetryEntries.get(TomlUtils.README);
@@ -108,7 +100,8 @@ public class PoetryToProjectDynamicMigrationSteps extends AbstractPoetryMigratio
     @Given("an existing pyproject.toml file with a dynamic entry but missing required field in project")
     public void an_existing_pyproject_toml_file_with_a_dynamic_entry_but_missing_required_field_in_project(DataTable dataTable) {
         pyProjectToml = new File(testTomlFileDirectory, "with-dynamic-in-project-but-missing-required-field.toml");
-        assertKeyExists(TomlUtils.PROJECT, TomlUtils.DYNAMIC, true);
+        Config projectEntries = loadAndAssertGroupExists(TomlUtils.PROJECT);
+        assertKeyExists(projectEntries, TomlUtils.DYNAMIC, true);
 
         List<String> expectedEntries = dataTable.asList(String.class);
         Object actualEntries = projectEntries.get(TomlUtils.DYNAMIC);
@@ -117,7 +110,8 @@ public class PoetryToProjectDynamicMigrationSteps extends AbstractPoetryMigratio
 
     @Then("the missing field is appended to the dynamic entry and now contains")
     public void the_missing_field_is_appended_to_the_dynamic_entry_and_contains(DataTable dataTable) {
-        assertKeyExists(TomlUtils.PROJECT, TomlUtils.DYNAMIC, true);
+        Config projectEntries = loadAndAssertGroupExists(TomlUtils.PROJECT);
+        assertKeyExists(projectEntries, TomlUtils.DYNAMIC, true);
 
         List<String> expectedEntries = dataTable.asList(String.class);
         Object actualEntries = projectEntries.get(TomlUtils.DYNAMIC);
@@ -127,7 +121,8 @@ public class PoetryToProjectDynamicMigrationSteps extends AbstractPoetryMigratio
     @Given("an existing pyproject.toml file with no dynamic in project")
     public void an_existing_pyproject_toml_file_with_no_dynamic_in_project() {
         pyProjectToml = new File(testTomlFileDirectory, "no-poetry-to-project-dynamic-migration.toml");
-        assertKeyExists(TomlUtils.PROJECT, TomlUtils.DYNAMIC, false);
+        Config projectEntries = loadAndAssertGroupExists(TomlUtils.PROJECT);
+        assertKeyExists(projectEntries, TomlUtils.DYNAMIC, false);
     }
     @Then("the poetry to project dynamic migration did not execute")
     public void the_poetry_to_project_requires_python_migration_did_not_execute() {

--- a/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryToProjectMigrationSteps.java
+++ b/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryToProjectMigrationSteps.java
@@ -1,46 +1,31 @@
 package org.technologybrewery.habushu.migration.poetryv2migrations;
 
+import com.electronwill.nightconfig.core.Config;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import org.technologybrewery.habushu.PoetryCommandHelperTestWrapper;
+
 import org.technologybrewery.habushu.util.TomlUtils;
 
 import java.io.File;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PoetryToProjectMigrationSteps extends AbstractPoetryMigrationSteps {
-    protected PoetryCommandHelperTestWrapper poetryHelper;
-    protected boolean mockIsPoetryVersionAtLeast2;
-
-    @Given("the Poetry version is at least \"2.0.0\"")
-    public void the_poetry_version_is_at_least_2_0_0(){
-        poetryHelper = new PoetryCommandHelperTestWrapper(new File("."), "2.0.0");
-        mockIsPoetryVersionAtLeast2 = poetryHelper.isPoetryVersionAtLeastMinimumVersion();
-        assertTrue(mockIsPoetryVersionAtLeast2, "The Poetry version found was less than 2.0.0");
-    }
-
-    @Given("the Poetry version is less than \"2.0.0\"")
-    public void poetry_version_is_less_than_2_0_0(){
-        poetryHelper = new PoetryCommandHelperTestWrapper(new File("."), "1.6.1");
-        mockIsPoetryVersionAtLeast2 = poetryHelper.isPoetryVersionAtLeastMinimumVersion();
-        assertFalse(mockIsPoetryVersionAtLeast2, "The Poetry version found greater than 2.0.0");
-    }
+    private boolean shouldExecute;
+    private boolean executionSucceeded;
 
     @Given("an existing pyproject.toml file with entries in the tool.poetry group")
     public void an_existing_pyproject_toml_file_with_entries_in_the_tool_poetry_group() {
         pyProjectToml = new File(testTomlFileDirectory, "with-fields-in-tool-poetry.toml");
-        loadAndAssertGroupExists(TomlUtils.TOOL_POETRY);
+        assertGroupExists(TomlUtils.TOOL_POETRY);
     }
 
     @When("the Habushu poetry-to-project migration executes")
     public void the_habushu_poetry_to_project_migration_executes() {
         PoetryToProjectMigration migration = new PoetryToProjectMigration();
         migration.setWorkingDirectory(new File("."));
-        migration.setIsPoetryVersionAtLeast2(mockIsPoetryVersionAtLeast2);
+        migration.setIsPoetryVersionAtLeast2(PoetryV2MigrationContext.getIsPoetryAtLeast2());
 
         shouldExecute = migration.shouldExecuteOnFile(pyProjectToml);
         executionSucceeded = (shouldExecute) ? migration.performMigration(pyProjectToml) : false;
@@ -48,34 +33,28 @@ public class PoetryToProjectMigrationSteps extends AbstractPoetryMigrationSteps 
 
     @Then("{int} entries exist in the tool.poetry group")
     public void entries_exist_in_the_tool_poetry_group(Integer expectedToolPoetryEntries) {
-        verifyExecutionOccurred();
-        loadAndAssertGroupExists(TomlUtils.TOOL_POETRY);
-
-        int actualEntries = getNumberOfEntries(toolPoetryEntries);
-        assertEquals(expectedToolPoetryEntries, actualEntries,
-                expectedToolPoetryEntries + " entries should remain in the tool.poetry group!");
+        verifyExecutionOccurred(shouldExecute, executionSucceeded);
+        Config toolPoetryEntries = loadAndAssertGroupExists(TomlUtils.TOOL_POETRY);
+        assertNumOfEntries(toolPoetryEntries, expectedToolPoetryEntries);
     }
 
     @Then("{int} entries exist in the project group")
     public void entries_exist_in_the_project_group(Integer expectedProjectEntries) {
-        loadAndAssertGroupExists(TomlUtils.PROJECT);
-
-        int actualEntries = getNumberOfEntries(projectEntries);
-        assertEquals(expectedProjectEntries, actualEntries,
-                expectedProjectEntries + " entries should remain in the project group!");
+        Config projectEntries = loadAndAssertGroupExists(TomlUtils.PROJECT);
+        assertNumOfEntries(projectEntries, expectedProjectEntries);
     }
 
     @Given("an existing pyproject.toml file with overlapping entries between the tool.poetry and project groups")
     public void an_existing_pyproject_toml_file_with_overlapping_entries_between_groups() {
         pyProjectToml = new File(testTomlFileDirectory, "with-overlapping-fields-in-tool-poetry-and-project.toml");
-        loadAndAssertGroupExists(TomlUtils.TOOL_POETRY);
+        assertGroupExists(TomlUtils.TOOL_POETRY);
+        assertGroupExists(TomlUtils.PROJECT);
     }
-
 
     @Given("an existing pyproject.toml file with no project group")
     public void an_existing_pyproject_toml_file_with_no_project_group() {
         pyProjectToml = new File(testTomlFileDirectory, "no-poetry-to-project-migration.toml");
-        loadAndAssertDoesNotExist(TomlUtils.PROJECT);
+        assertGroupDoesNotExist(TomlUtils.PROJECT);
     }
 
     @Then("the poetry to project migration did not execute")

--- a/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryToProjectRequiresPythonMigrationSteps.java
+++ b/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryToProjectRequiresPythonMigrationSteps.java
@@ -1,65 +1,54 @@
 package org.technologybrewery.habushu.migration.poetryv2migrations;
 
+import com.electronwill.nightconfig.core.Config;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import org.technologybrewery.habushu.PoetryCommandHelperTestWrapper;
+
 import org.technologybrewery.habushu.util.TomlUtils;
 
 import java.io.File;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PoetryToProjectRequiresPythonMigrationSteps extends AbstractPoetryMigrationSteps {
-    protected PoetryCommandHelperTestWrapper poetryHelper;
-    protected boolean mockIsPoetryVersionAtLeast2;
-
-
-    @Given("Poetry version is at least \"2.0.0\"")
-    public void poetry_version_is_at_least_2_0_0(){
-        poetryHelper = new PoetryCommandHelperTestWrapper(new File("."), "2.0.0");
-        mockIsPoetryVersionAtLeast2 = poetryHelper.isPoetryVersionAtLeastMinimumVersion();
-        assertTrue(mockIsPoetryVersionAtLeast2, "The Poetry version found was less than 2.0.0");
-    }
-
-    @Given("Poetry version is less than \"2.0.0\"")
-    public void poetry_version_is_less_than_2_0_0(){
-        poetryHelper = new PoetryCommandHelperTestWrapper(new File("."), "1.6.1");
-        mockIsPoetryVersionAtLeast2 = poetryHelper.isPoetryVersionAtLeastMinimumVersion();
-        assertFalse(mockIsPoetryVersionAtLeast2, "The Poetry version found greater than 2.0.0");
-    }
+    private boolean shouldExecute;
+    private boolean executionSucceeded;
 
     @Given("an existing pyproject.toml file with no requires-python entry in the project group")
     public void an_existing_pyproject_toml_file_with_no_requires_python_entry_in_the_project_group() {
         pyProjectToml = new File(testTomlFileDirectory, "with-no-python-requirement-tag-in-project.toml");
-        assertKeyExists(TomlUtils.PROJECT, TomlUtils.REQUIRES_PYTHON, false);
+        Config projectEntries = loadAndAssertGroupExists(TomlUtils.PROJECT);
+        assertKeyExists(projectEntries, TomlUtils.REQUIRES_PYTHON, false);
     }
 
     @Given("an existing pyproject.toml file with a requires-python entry in the project group")
     public void an_existing_pyproject_toml_file_with_a_requires_python_entry_in_project_group() {
         pyProjectToml = new File(testTomlFileDirectory, "with-python-requirement-tag-in-project.toml");
-        assertKeyExists(TomlUtils.PROJECT, TomlUtils.REQUIRES_PYTHON, true);
+        Config projectEntries = loadAndAssertGroupExists(TomlUtils.PROJECT);
+        assertKeyExists(projectEntries, TomlUtils.REQUIRES_PYTHON, true);
     }
 
     @Given("an existing pyproject.toml file with a badly formatted requires-python entry in the project group")
     public void an_existing_pyproject_toml_file_with_a_badly_formatted_requires_python_entry_in_project_group() {
         pyProjectToml = new File(testTomlFileDirectory, "with-python-requirement-tag-in-project-badly-formatted.toml");
-        assertKeyExists(TomlUtils.PROJECT, TomlUtils.REQUIRES_PYTHON, true);
+        Config projectEntries = loadAndAssertGroupExists(TomlUtils.PROJECT);
+        assertKeyExists(projectEntries, TomlUtils.REQUIRES_PYTHON, true);
     }
 
     @Given("an existing pyproject.toml file with no requires-python")
     public void an_existing_pyproject_toml_file_without_a_requires_python_entry_in_project_group() {
         pyProjectToml = new File(testTomlFileDirectory, "no-poetry-to-project-python-requirement-tag-migration.toml");
-        assertKeyExists(TomlUtils.PROJECT, TomlUtils.REQUIRES_PYTHON, false);
+        Config projectEntries = loadAndAssertGroupExists(TomlUtils.PROJECT);
+        assertKeyExists(projectEntries, TomlUtils.REQUIRES_PYTHON, false);
     }
 
     @When("the Habushu poetry-to-project-requires-python migration executes")
     public void the_habushu_poetry_to_project_requires_python_migration_executes() {
         PoetryToProjectRequiresPythonMigration migration = new PoetryToProjectRequiresPythonMigration();
         migration.setWorkingDirectory(new File("."));
-        migration.setIsPoetryVersionAtLeast2(mockIsPoetryVersionAtLeast2);
+        migration.setIsPoetryVersionAtLeast2(PoetryV2MigrationContext.getIsPoetryAtLeast2());
 
         shouldExecute = migration.shouldExecuteOnFile(pyProjectToml);
         executionSucceeded = (shouldExecute) ? migration.performMigration(pyProjectToml) : false;
@@ -67,15 +56,17 @@ public class PoetryToProjectRequiresPythonMigrationSteps extends AbstractPoetryM
 
     @Then("the requires-python entry is added to the project group and set to {string}")
     public void the_requires_python_entry_is_added_to_the_project_group_and_set_to(String expectedPythonVersion) {
-        verifyExecutionOccurred();
+        verifyExecutionOccurred(shouldExecute, executionSucceeded);
+        Config projectEntries = loadAndAssertGroupExists(TomlUtils.PROJECT);
 
-        assertKeyExists(TomlUtils.PROJECT, TomlUtils.REQUIRES_PYTHON, true);
+        assertKeyExists(projectEntries, TomlUtils.REQUIRES_PYTHON, true);
         assertEquals(expectedPythonVersion, projectEntries.get(TomlUtils.REQUIRES_PYTHON).toString(),"requires-python was set incorrectly in [project]");
     }
 
     @Then("the python entry no longer exists in the tool.poetry.dependencies group")
     public void the_python_entry_no_longer_exists_in_the_tool_poetry_group() {
-        assertKeyExists(TomlUtils.TOOL_POETRY_DEPENDENCIES, TomlUtils.PYTHON, false);
+        Config toolPoetryDepsEntries = loadAndAssertGroupExists(TomlUtils.TOOL_POETRY_DEPENDENCIES);
+        assertKeyExists(toolPoetryDepsEntries, TomlUtils.PYTHON, false);
     }
 
     @Then("the poetry to project requires python migration did not execute")

--- a/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryTomlMigrationSteps.java
+++ b/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryTomlMigrationSteps.java
@@ -1,64 +1,49 @@
 package org.technologybrewery.habushu.migration.poetryv2migrations;
 
+import com.electronwill.nightconfig.core.Config;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import org.technologybrewery.habushu.PoetryCommandHelperTestWrapper;
 import org.technologybrewery.habushu.util.TomlUtils;
 
 import java.io.File;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class PoetryTomlMigrationSteps extends AbstractPoetryMigrationSteps {
-    protected PoetryCommandHelperTestWrapper poetryHelper;
-    protected boolean mockIsPoetryVersionAtLeast2;
-
-    @Given("Poetry is at least \"2.0.0\"")
-    public void poetry_at_least_2_0_0(){
-        poetryHelper = new PoetryCommandHelperTestWrapper(new File("."), "2.0.0");
-        mockIsPoetryVersionAtLeast2 = poetryHelper.isPoetryVersionAtLeastMinimumVersion();
-        assertTrue(mockIsPoetryVersionAtLeast2, "The Poetry version found was less than 2.0.0");
-    }
-
-    @Given("Poetry is less than \"2.0.0\"")
-    public void poetry_is_less_than_2_0_0(){
-        poetryHelper = new PoetryCommandHelperTestWrapper(new File("."), "1.6.1");
-        mockIsPoetryVersionAtLeast2 = poetryHelper.isPoetryVersionAtLeastMinimumVersion();
-        assertFalse(mockIsPoetryVersionAtLeast2, "The Poetry version found greater than 2.0.0");
-    }
+    private boolean shouldExecute;
+    private boolean executionSucceeded;
 
     @Given("an existing poetry.toml file with deprecated configurations in [virtualenvs] and [experimental]")
     public void an_existing_poetry_toml_file_with_deprecated_configurations_in_virtualenvs_and_experimental() {
         pyProjectToml = new File(testTomlFileDirectory, "with-deprecated-virtualenvs-and-experimental-configs.toml");
-        loadAndAssertGroupExists(TomlUtils.VIRTUAL_ENVS);
-        loadAndAssertGroupExists(TomlUtils.EXPERIMENTAL);
+        assertGroupExists(TomlUtils.VIRTUAL_ENVS);
+        assertGroupExists(TomlUtils.EXPERIMENTAL);
     }
 
     @Given("an existing poetry.toml file with deprecated configurations in [virtualenvs]")
     public void an_existing_poetry_toml_file_with_deprecated_configs_in_virtualenvs() {
         pyProjectToml = new File(testTomlFileDirectory, "with-deprecated-virtualenvs-config.toml");
-        loadAndAssertGroupExists(TomlUtils.VIRTUAL_ENVS);
+        assertGroupExists(TomlUtils.VIRTUAL_ENVS);
     }
 
     @Given("an existing poetry.toml file with one deprecated configuration in [experimental] out of multiple configurations")
     public void an_existing_poetry_toml_file_with_one_deprecated_config_in_experimental_out_of_multiple_configs() {
         pyProjectToml = new File(testTomlFileDirectory, "with-one-deprecated-experimental-out-of-multiple.toml");
-        loadAndAssertGroupExists(TomlUtils.EXPERIMENTAL);
+        assertGroupExists(TomlUtils.EXPERIMENTAL);
     }
 
     @Given("an existing poetry.toml file with one deprecated configuration in [experimental]")
     public void an_existing_poetry_toml_file_with_one_deprecated_configs_in_experimental() {
         pyProjectToml = new File(testTomlFileDirectory, "with-one-deprecated-experimental-system-git-config.toml");
-        loadAndAssertGroupExists(TomlUtils.EXPERIMENTAL);
+        assertGroupExists(TomlUtils.EXPERIMENTAL);
     }
 
     @When("the Habushu poetry-toml migration executes")
     public void the_habushu_poetry_toml_migration_executes() {
         PoetryTomlMigration migration = new PoetryTomlMigration();
         migration.setWorkingDirectory(new File("."));
-        migration.setIsPoetryVersionAtLeast2(mockIsPoetryVersionAtLeast2);
+        migration.setIsPoetryVersionAtLeast2(PoetryV2MigrationContext.getIsPoetryAtLeast2());
 
         shouldExecute = migration.shouldExecuteOnFile(pyProjectToml);
         executionSucceeded = (shouldExecute) ? migration.performMigration(pyProjectToml) : false;
@@ -66,34 +51,34 @@ public class PoetryTomlMigrationSteps extends AbstractPoetryMigrationSteps {
 
     @Then("{int} entries exist in the virtualenvs group")
     public void entries_exist_in_the_virtualenvs_group(Integer expectedVirtualEnvsEntries) {
-        verifyExecutionOccurred();
-        loadAndAssertGroupExists(TomlUtils.VIRTUAL_ENVS);
+        verifyExecutionOccurred(shouldExecute, executionSucceeded);
+        Config virtualEnvsEntries = loadAndAssertGroupExists(TomlUtils.VIRTUAL_ENVS);
         assertNumOfEntries(virtualEnvsEntries, expectedVirtualEnvsEntries);
     }
 
     @Then("{int} entries exist in the experimental group")
     public void entries_exist_in_the_experimental_group(Integer expectedExperimentalEntries) {
-        verifyExecutionOccurred();
-        loadAndAssertGroupExists(TomlUtils.EXPERIMENTAL);
+        verifyExecutionOccurred(shouldExecute, executionSucceeded);
+        Config experimentalEntries = loadAndAssertGroupExists(TomlUtils.EXPERIMENTAL);
         assertNumOfEntries(experimentalEntries, expectedExperimentalEntries);
     }
 
     @Then("no entry exists in the experimental group")
     public void no_entry_exists_in_the_experimental_group() {
-        verifyExecutionOccurred();
-        loadAndAssertDoesNotExist(TomlUtils.EXPERIMENTAL);
+        verifyExecutionOccurred(shouldExecute, executionSucceeded);
+        assertGroupDoesNotExist(TomlUtils.EXPERIMENTAL);
     }
 
     @Given("an existing poetry.toml file with no deprecated configurations in [virtualenvs]")
     public void an_existing_poetry_toml_file_with_no_deprecated_configs_in_virtualenvs() {
         pyProjectToml = new File(testTomlFileDirectory, "no-poetry-toml-migration.toml");
-        loadAndAssertGroupExists(TomlUtils.VIRTUAL_ENVS);
+        assertGroupExists(TomlUtils.VIRTUAL_ENVS);
     }
 
     @Given("an existing poetry.toml file with no deprecated configurations in [experimental]")
     public void an_existing_poetry_toml_file_with_no_deprecated_configs_in_experimental() {
         pyProjectToml = new File(testTomlFileDirectory, "no-poetry-toml-migration.toml");
-        loadAndAssertGroupExists(TomlUtils.EXPERIMENTAL);
+        assertGroupExists(TomlUtils.EXPERIMENTAL);
     }
 
     @Then("the poetry-toml migration did not execute")

--- a/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryV2MigrationContext.java
+++ b/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryV2MigrationContext.java
@@ -1,0 +1,45 @@
+package org.technologybrewery.habushu.migration.poetryv2migrations;
+
+import io.cucumber.java.Before;
+import io.cucumber.java.en.Given;
+import org.technologybrewery.habushu.PoetryCommandHelperTestWrapper;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Shared context for BDD steps to verify whether the Poetry version
+ * is at least 2.0.0 or not.
+ */
+public class PoetryV2MigrationContext {
+    public static boolean isPoetryAtLeast2;
+
+    public static void setPoetryAtLeast2(boolean mockIsPoetryVersionAtLeast2){
+        isPoetryAtLeast2 = mockIsPoetryVersionAtLeast2;
+    }
+
+    public static boolean getIsPoetryAtLeast2(){
+        return isPoetryAtLeast2;
+    }
+
+    @Before("@poetry-v2-migration")
+    public void resetPoetryContext() {
+        setPoetryAtLeast2(false);
+    }
+
+    @Given("the Poetry version is at least \"2.0.0\"")
+    public void poetry_version_is_at_least_2_0_0() {
+        boolean mockIsPoetryAtLeast2 = new PoetryCommandHelperTestWrapper(new File("."), "2.0.0").isPoetryVersionAtLeastMinimumVersion();
+        assertTrue(mockIsPoetryAtLeast2, "Unexpected Poetry version found.");
+        setPoetryAtLeast2(mockIsPoetryAtLeast2);
+    }
+
+    @Given("the Poetry version is less than \"2.0.0\"")
+    public void poetry_version_is_less_than_2_0_0(){
+        boolean mockIsPoetryAtLeast2 = new PoetryCommandHelperTestWrapper(new File("."), "1.6.1").isPoetryVersionAtLeastMinimumVersion();
+        assertFalse(mockIsPoetryAtLeast2, "Unexpected Poetry version found.");
+        setPoetryAtLeast2(mockIsPoetryAtLeast2);
+    }
+}

--- a/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-inline-deps-table-under-tool-poetry.toml
+++ b/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-inline-deps-table-under-tool-poetry.toml
@@ -1,0 +1,22 @@
+[tool.poetry]
+dependencies = { krausening = "19", cryptography = "42.0.0"}
+
+[project]
+name = "with-inline-deps-under-tool-poetry"
+description = "Test skipping removal of tool.poetry header when Poetry version is at least 2.0.0"
+version = "0.1.0.dev"
+authors = [
+    {name = "Test",email = "blah@foobar.com"}
+]
+maintainers = [
+    {name = "Test",email = "blah@foobar.com"}
+]
+requires-python = ">=3.12,<4"
+dynamic = ["version", "dependencies"]
+
+[tool.poetry.group.dev.dependencies]
+kappa-maki = ">=1.0.0"
+
+[build-system]
+requires = ["poetry-core>=1.6.0"]
+build-backend = "poetry.core.masonry.api"

--- a/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-no-entries-under-tool-poetry-and-tool-poetry-dependencies.toml
+++ b/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-no-entries-under-tool-poetry-and-tool-poetry-dependencies.toml
@@ -1,0 +1,23 @@
+[tool.poetry]
+
+[tool.poetry.dependencies]
+
+[project]
+name = "with-no-entries-under-tool-poetry-and-tool-poetry-dependencies"
+description = "Test removing empty tool.poetry and tool.poetry.dependencies headers when Poetry version is at least 2.0.0"
+version = "0.1.0.dev"
+authors = [
+    {name = "Test",email = "blah@foobar.com"}
+]
+maintainers = [
+    {name = "Test",email = "blah@foobar.com"}
+]
+requires-python = ">=3.12,<4"
+dynamic = ["version", "dependencies"]
+
+[tool.poetry.group.dev.dependencies]
+kappa-maki = ">=1.0.0"
+
+[build-system]
+requires = ["poetry-core>=1.6.0"]
+build-backend = "poetry.core.masonry.api"

--- a/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-no-entries-under-tool-poetry-dependencies.toml
+++ b/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-no-entries-under-tool-poetry-dependencies.toml
@@ -1,0 +1,23 @@
+[tool.poetry]
+name = "with-no-entries-under-tool-poetry-dependencies"
+
+[tool.poetry.dependencies]
+
+[project]
+description = "Test removing empty tool.poetry.dependencies header when Poetry version is at least 2.0.0"
+version = "0.1.0.dev"
+authors = [
+    {name = "Test",email = "blah@foobar.com"}
+]
+maintainers = [
+    {name = "Test",email = "blah@foobar.com"}
+]
+requires-python = ">=3.12,<4"
+dynamic = ["version", "dependencies"]
+
+[tool.poetry.group.dev.dependencies]
+kappa-maki = ">=1.0.0"
+
+[build-system]
+requires = ["poetry-core>=1.6.0"]
+build-backend = "poetry.core.masonry.api"

--- a/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-no-entries-under-tool-poetry.toml
+++ b/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-no-entries-under-tool-poetry.toml
@@ -1,0 +1,26 @@
+[tool.poetry]
+
+[tool.poetry.dependencies]
+krausening = "19"
+cryptography = "42.0.0"
+uvicorn = {version = "0.18.0", extras = ["standard"]}
+
+[project]
+name = "with-no-entries-under-tool-poetry"
+description = "Test removing empty tool.poetry header when Poetry version is at least 2.0.0"
+version = "0.1.0.dev"
+authors = [
+    {name = "Test",email = "blah@foobar.com"}
+]
+maintainers = [
+    {name = "Test",email = "blah@foobar.com"}
+]
+requires-python = ">=3.12,<4"
+dynamic = ["version", "dependencies"]
+
+[tool.poetry.group.dev.dependencies]
+kappa-maki = ">=1.0.0"
+
+[build-system]
+requires = ["poetry-core>=1.6.0"]
+build-backend = "poetry.core.masonry.api"

--- a/habushu-maven-plugin/src/test/resources/specifications/poetry-v2/poetry-remove-empty-toml-migration.feature
+++ b/habushu-maven-plugin/src/test/resources/specifications/poetry-v2/poetry-remove-empty-toml-migration.feature
@@ -1,0 +1,33 @@
+@poetry-v2-migration
+Feature: Test automatic migrations to remove empty [tool.poetry] and [tool.poetry.dependencies] from pyproject.toml file based on given Poetry version
+
+  Scenario: Poetry version is at least 2.0.0 and the poetry-remove-empty-toml migration removes empty [tool.poetry] header
+    Given the Poetry version is at least "2.0.0"
+    And an existing pyproject.toml file with no direct entries under the tool.poetry header
+    When the Habushu poetry-remove-empty-toml migration executes
+    Then the tool.poetry header is removed
+
+  Scenario: Poetry version is at least 2.0.0 and the poetry-remove-empty-toml migration removes empty [tool.poetry.dependencies] header
+    Given the Poetry version is at least "2.0.0"
+    And an existing pyproject.toml file with no direct entries under the tool.poetry.dependencies header
+    When the Habushu poetry-remove-empty-toml migration executes
+    Then the tool.poetry.dependencies header is removed
+
+  Scenario: Poetry version is at least 2.0.0 and the poetry-remove-empty-toml migration removes empty [tool.poetry] and [tool.poetry.dependencies] headers
+    Given the Poetry version is at least "2.0.0"
+    And an existing pyproject.toml file with no direct entries under the tool.poetry and tool.poetry.dependencies headers
+    When the Habushu poetry-remove-empty-toml migration executes
+    Then the tool.poetry and tool.poetry.dependencies headers are removed
+
+  Scenario: Poetry version is at least 2.0.0 and the poetry-remove-empty-toml migration does not remove [tool.poetry] with inline dependencies table
+    Given the Poetry version is at least "2.0.0"
+    And an existing pyproject.toml file with an inline dependencies table under the tool.poetry header
+    When the Habushu poetry-remove-empty-toml migration executes
+    Then the tool.poetry header is not removed
+
+  Scenario: Poetry version is less than 2.0.0 and the poetry-remove-empty-toml migration does not execute
+    Given the Poetry version is at least "2.0.0"
+    And an existing pyproject.toml file with no direct entries under the tool.poetry header
+    When the Habushu poetry-remove-empty-toml migration executes
+    Then the poetry-remove-empty-toml migration did not execute
+

--- a/habushu-maven-plugin/src/test/resources/specifications/poetry-v2/poetry-to-project-dynamic-migration.feature
+++ b/habushu-maven-plugin/src/test/resources/specifications/poetry-v2/poetry-to-project-dynamic-migration.feature
@@ -1,8 +1,8 @@
-@poetryToProjectDynamicMigration
+@poetry-v2-migration
 Feature: Test automatic addition of dynamic field to [project] section of pyproject.toml file for projects using Poetry version of at least 2.0.0
 
   Scenario: Poetry version is at least 2.0.0 and [project] section does not have dynamic entry and [tool.poetry] does not have a readme so only dynamic = ["version", "dependencies"] is injected
-    Given Poetry version at least "2.0.0"
+    Given the Poetry version is at least "2.0.0"
     And an existing pyproject.toml file with no dynamic in project and no readme in tool.poetry
     When the Habushu poetry-to-project-dynamic migration executes
     Then the dynamic entry is added to the project group and contains
@@ -10,7 +10,7 @@ Feature: Test automatic addition of dynamic field to [project] section of pyproj
       | dependencies |
 
   Scenario: Poetry version is at least 2.0.0 and [project] section does not have dynamic entry and [tool.poetry] has a single readme so dynamic = ["version", "dependencies"] is injected and readme is migrated from [tool.poetry] to [project]
-    Given Poetry version at least "2.0.0"
+    Given the Poetry version is at least "2.0.0"
     And an existing pyproject.toml file with no dynamic in project and with a single readme in tool.poetry
     When the Habushu poetry-to-project-dynamic migration executes
     Then the dynamic entry is added to the project group and contains
@@ -20,7 +20,7 @@ Feature: Test automatic addition of dynamic field to [project] section of pyproj
     And the readme entry is removed from the tool.poetry group
 
   Scenario: Poetry version is at least 2.0.0 and [project] section does not have dynamic entry and [tool.poetry] has multiple readmes so dynamic = ["version", "dependencies", "readme"] is injected and the readmes remains in tool.poetry
-    Given Poetry version at least "2.0.0"
+    Given the Poetry version is at least "2.0.0"
     And an existing pyproject.toml file with no dynamic in project and with multiple readmes in tool.poetry
     When the Habushu poetry-to-project-dynamic migration executes
     Then the dynamic entry is added to the project group and contains
@@ -32,7 +32,7 @@ Feature: Test automatic addition of dynamic field to [project] section of pyproj
       | src/example_1/README.md  |
 
   Scenario: Poetry version is at least 2.0.0 and [project] section has a dynamic entry but it is missing one of the required fields so the missing field is appended to the existing dynamic list. For example dynamic = ["version"] becomes dynamic = ["version", "dependencies"].
-    Given Poetry version at least "2.0.0"
+    Given the Poetry version is at least "2.0.0"
     And an existing pyproject.toml file with a dynamic entry but missing required field in project
       |version       |
     When the Habushu poetry-to-project-dynamic migration executes
@@ -41,7 +41,7 @@ Feature: Test automatic addition of dynamic field to [project] section of pyproj
       | dependencies |
 
   Scenario: Poetry version is less than 2.0.0 and the poetry-to-project-dynamic migration does not execute
-    Given Poetry version less than "2.0.0"
+    Given the Poetry version is less than "2.0.0"
     And an existing pyproject.toml file with no dynamic in project
-    When the Habushu poetry-to-project migration executes
+    When the Habushu poetry-to-project-dynamic migration executes
     Then the poetry to project dynamic migration did not execute

--- a/habushu-maven-plugin/src/test/resources/specifications/poetry-v2/poetry-to-project-migration.feature
+++ b/habushu-maven-plugin/src/test/resources/specifications/poetry-v2/poetry-to-project-migration.feature
@@ -1,4 +1,4 @@
-@poetryToProjectMigration
+@poetry-v2-migration
 Feature: Test automatic migrations of required fields from [tool.project] to [project] applied to pyproject.toml file based on given Poetry version
 
   Scenario Outline: Poetry version is at least 2.0.0 and the poetry-to-project migration moves fields from [tool.poetry] to [project]

--- a/habushu-maven-plugin/src/test/resources/specifications/poetry-v2/poetry-to-project-requires-python-migration.feature
+++ b/habushu-maven-plugin/src/test/resources/specifications/poetry-v2/poetry-to-project-requires-python-migration.feature
@@ -1,27 +1,27 @@
-@poetryToProjectRequiresPythonMigration
+@poetry-v2-migration
 Feature: Test automatic migrations of python dependency from [tool.project] to [project] applied to pyproject.toml file based on given Poetry version
 
   Scenario: Poetry version is at least 2.0.0 and the poetry-to-project-requires-python migration adds a new requires-python entry to [project] group and removes the python dependency from [tool.poetry.dependencies] group
-    Given Poetry version is at least "2.0.0"
+    Given the Poetry version is at least "2.0.0"
     And an existing pyproject.toml file with no requires-python entry in the project group
     When the Habushu poetry-to-project-requires-python migration executes
     Then the requires-python entry is added to the project group and set to ">=3.11,<4"
     And the python entry no longer exists in the tool.poetry.dependencies group
 
   Scenario: Poetry version is at least 2.0.0 and project group already has a requires-python entry so the migration does not execute
-    Given Poetry version is at least "2.0.0"
+    Given the Poetry version is at least "2.0.0"
     And an existing pyproject.toml file with a requires-python entry in the project group
     When the Habushu poetry-to-project-requires-python migration executes
     Then the poetry to project requires python migration did not execute
 
   Scenario: Poetry version is at least 2.0.0 and project group already has a requires-python entry in "^" format, so the migration executes and alters it to ">=,<" format
-    Given Poetry version is at least "2.0.0"
+    Given the Poetry version is at least "2.0.0"
     And an existing pyproject.toml file with a badly formatted requires-python entry in the project group
     When the Habushu poetry-to-project-requires-python migration executes
     Then the requires-python entry is added to the project group and set to ">=3.11,<4"
 
   Scenario: Poetry version is less than 2.0.0 so the migration does not execute
-    Given Poetry version is less than "2.0.0"
+    Given the Poetry version is less than "2.0.0"
     And an existing pyproject.toml file with no requires-python
     When the Habushu poetry-to-project-requires-python migration executes
     Then the poetry to project requires python migration did not execute

--- a/habushu-maven-plugin/src/test/resources/specifications/poetry-v2/poetry-toml-migration.feature
+++ b/habushu-maven-plugin/src/test/resources/specifications/poetry-v2/poetry-toml-migration.feature
@@ -1,8 +1,8 @@
-@poetryTomlMigration
+@poetry-v2-migration
 Feature: Test automatic migrations of deprecated fields applied to poetry.toml file based on given Poetry version
 
   Scenario Outline: Poetry version is at least 2.0.0 and the poetry-toml migration removes deprecated virtualenvs and experimental fields from poetry.toml file
-    Given Poetry is at least "2.0.0"
+    Given the Poetry version is at least "2.0.0"
     And an existing poetry.toml file with deprecated configurations in [virtualenvs] and [experimental]
     When the Habushu poetry-toml migration executes
     Then <expectedVirtualEnvEntries> entries exist in the virtualenvs group
@@ -13,7 +13,7 @@ Feature: Test automatic migrations of deprecated fields applied to poetry.toml f
       | 2                         | 1                          |
 
   Scenario Outline: Poetry version is at least 2.0.0 and the poetry-toml migration removes deprecated virtualenvs fields from poetry.toml file
-    Given Poetry is at least "2.0.0"
+    Given the Poetry version is at least "2.0.0"
     And an existing poetry.toml file with deprecated configurations in [virtualenvs]
     When the Habushu poetry-toml migration executes
     Then <expectedVirtualEnvEntries> entries exist in the virtualenvs group
@@ -23,7 +23,7 @@ Feature: Test automatic migrations of deprecated fields applied to poetry.toml f
       | 2                         |
 
   Scenario Outline: Poetry version is at least 2.0.0 and the poetry-toml migration removes one deprecated experimental field from poetry.toml file
-    Given Poetry is at least "2.0.0"
+    Given the Poetry version is at least "2.0.0"
     And an existing poetry.toml file with one deprecated configuration in [experimental] out of multiple configurations
     When the Habushu poetry-toml migration executes
     Then <expectedExperimentalEntries> entries exist in the experimental group
@@ -33,25 +33,25 @@ Feature: Test automatic migrations of deprecated fields applied to poetry.toml f
       | 1                           |
 
   Scenario: Poetry version is at least 2.0.0 and the poetry-toml migration removes the only deprecated experimental field from poetry.toml file
-    Given Poetry is at least "2.0.0"
+    Given the Poetry version is at least "2.0.0"
     And an existing poetry.toml file with one deprecated configuration in [experimental]
     When the Habushu poetry-toml migration executes
     Then no entry exists in the experimental group
 
   Scenario: Poetry version is at least 2.0.0 but the poetry.toml file has no deprecated configs in [virtualenvs] so the poetry-toml migration does not run
-    Given Poetry is at least "2.0.0"
+    Given the Poetry version is at least "2.0.0"
     And an existing poetry.toml file with no deprecated configurations in [virtualenvs]
     When the Habushu poetry-toml migration executes
     Then the poetry-toml migration did not execute
 
   Scenario: Poetry version is at least 2.0.0 but the poetry.toml file has no deprecated configs in [experimental] so the poetry-toml migration does not run
-    Given Poetry is at least "2.0.0"
+    Given the Poetry version is at least "2.0.0"
     And an existing poetry.toml file with no deprecated configurations in [experimental]
     When the Habushu poetry-toml migration executes
     Then the poetry-toml migration did not execute
 
   Scenario: Poetry version is less than 2.0.0 and the poetry-toml migration does not execute
-    Given Poetry is less than "2.0.0"
+    Given the Poetry version is less than "2.0.0"
     And an existing poetry.toml file with deprecated configurations in [virtualenvs] and [experimental]
     When the Habushu poetry-toml migration executes
     Then the poetry-toml migration did not execute


### PR DESCRIPTION
#354 

- `PoetryRemoveEmptyTomlMigration` to remove empty `[tool.poetry]` and `[tool.poetry.dependencies]` headers from `pyproject.toml` if they exist
- update documentation to include info about new migration
- wrote unit tests and refactored previous Poetry v2 Migration tests to share context for checking if Poetry version at least 2.0.0
- ran migration against all example Poetry `pyproject.toml` files