### PR TITLE
[#361] Poetry v2 Migration - python inline dependencies fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Pyenv is utilized to install and use the specified version of Python, while Poet
 When on Poetry v2.0.0 and later, Baton migrations will automatically run on all `pyproject.toml` and `poetry.toml` files in your Habushu project.
 This update introduces a number of migrations that ensure configurations are more in line with [PEP 621](https://peps.python.org/pep-0621/).
 - `PoetryToProjectMigration`: Adds `[project]` section into TOML file and moves relevant fields from `[tool.poetry]` to `[project]`
-- `PoetryToProjectRequiresPythonMigration`: Relocates the Python dependency from `[tool.poetry.dependencies]` to the `requires-python` entry under `[project]`
+- `PoetryToProjectRequiresPythonMigration`: Relocates the Python dependency from `tool.poetry.dependencies` to the `requires-python` entry under `[project]`. If there are `python` version constraints listed in `project.requires-python` and `tool.poetry.dependencies`, then the duplicate constraint is removed from `tool.poetry.dependencies`
 - `PoetryToProjectDynamicMigration`: Introduces a `dynamic` field under `[project]` that automatically includes `version` and `dependency`, if not already present. If a single `readme` (as a string) is included in `[tool.poetry]`, then migrates it from `[tool.poetry]` to `[project]`. If multiple `readme` values are defined (as a table) in `[tool.poetry]`, `readme` is added to the `dynamic` field list.
 - `PoetryTomlMigration`: Removes deprecated configurations from the `poetry.toml` file
 - `PoetryRemoveEmptyTomlMigration`: Removes any empty `[tool.poetry]` and `[tool.poetry.dependencies]` headers from `pyproject.toml`

--- a/examples/poetry/habushu-poetry-install-from-dev-repo/pom.xml
+++ b/examples/poetry/habushu-poetry-install-from-dev-repo/pom.xml
@@ -17,6 +17,18 @@
 
     <build>
         <directory>dist</directory>
+        <plugins>
+            <plugin>
+                <groupId>org.technologybrewery.habushu</groupId>
+                <artifactId>habushu-maven-plugin</artifactId>
+                <configuration>
+                    <deactivateMigrations>
+                        <!--  Skip migration that removes empty TOML headers to keep functional example valid-->
+                        <deactivateMigration>poetry-v2-remove-empty-toml-migration</deactivateMigration>
+                    </deactivateMigrations>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
     <profiles>

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryToProjectRequiresPythonMigration.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryToProjectRequiresPythonMigration.java
@@ -11,72 +11,80 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
- * Provides functionality to migrate python dependency from the [tool.poetry.dependencies] section to the [project] section of a TOML file.
+ * Provides functionality to migrate python dependency from the tool.poetry.dependencies section to the [project] section of a TOML file.
+ * If python dependency exists in the tool.poetry.dependencies and the project section,
+ * then the duplicate constraint is removed from tool.poetry.dependencies.
  * Runs when on Poetry v2.0.0 or later.
  */
 public class PoetryToProjectRequiresPythonMigration extends AbstractPoetryMigration{
     private static final Logger logger = LoggerFactory.getLogger(PoetryToProjectRequiresPythonMigration.class);
     private String pythonDependencyVersion;
-    private boolean updateFaultyFormat = false;
+    private boolean updateFaultyFormat;
+    private boolean missingRequiresPython;
+    private boolean hasInlineDependenciesTable;
+    private boolean hasPoetryPython;
+    private List<String> poetryDependenciesKeys = new ArrayList<>();
 
     @Override
     protected boolean shouldExecuteOnFile(File file) {
-        boolean shouldExecute = false;
-
         if (isPoetryProject(file) && isPoetryVersionAtLeast2) {
             try (FileConfig tomlFileConfig = FileConfig.of(file)){
                 tomlFileConfig.load();
-                Optional<Config> projectGroup = tomlFileConfig.getOptional(TomlUtils.PROJECT);
 
+                Optional<Config> poetryDependenciesGroup = tomlFileConfig.getOptional(TomlUtils.TOOL_POETRY_DEPENDENCIES);
+                if (poetryDependenciesGroup.isPresent()) {
+                    Config poetryDependenciesGroupEntry = poetryDependenciesGroup.get();
+
+                    if (poetryDependenciesGroupEntry.contains(TomlUtils.PYTHON)){
+                        hasPoetryPython = true;
+                        poetryDependenciesKeys = poetryDependenciesGroupEntry.entrySet().stream().map(Config.Entry::getKey).collect(Collectors.toList());
+                        pythonDependencyVersion = poetryDependenciesGroupEntry.get(TomlUtils.PYTHON);
+
+                        if (pythonDependencyVersion.contains(TomlUtils.CARET)) {
+                            pythonDependencyVersion = TomlUtils.refactorCaretIntoGreaterThanLessThan(pythonDependencyVersion);
+                        }
+
+                        List<String> allTomlHeaders = TomlUtils.extractTomlSectionHeaders(file);
+                        hasInlineDependenciesTable = !allTomlHeaders.contains(TomlUtils.TOOL_POETRY_DEPENDENCIES);
+                    }
+                }
+
+                Optional<Config> projectGroup = tomlFileConfig.getOptional(TomlUtils.PROJECT);
                 if (projectGroup.isPresent()){
                     Config projectGroupEntry = projectGroup.get();
 
                     if (!projectGroupEntry.contains(TomlUtils.REQUIRES_PYTHON)) {
-                        shouldExecute = true;
+                        missingRequiresPython = true;
                         logger.info("Adding to [{}] group entry! ({})", TomlUtils.PROJECT, TomlUtils.REQUIRES_PYTHON);
                     } else {
                         String requiresPythonSemver = projectGroupEntry.get(TomlUtils.REQUIRES_PYTHON);
-                        if (requiresPythonSemver.contains(TomlUtils.CARROT)) {
+                        if (requiresPythonSemver.contains(TomlUtils.CARET)) {
                             updateFaultyFormat = true;
-                            shouldExecute = true;
-                            pythonDependencyVersion = TomlUtils.refactorCarrotIntoGreaterThanLessThan(requiresPythonSemver);
+                            pythonDependencyVersion = TomlUtils.refactorCaretIntoGreaterThanLessThan(requiresPythonSemver);
                             logger.info("Reformatting ({}) in group entry [{}] to use >=,< notation!",
                                     TomlUtils.REQUIRES_PYTHON,
                                     TomlUtils.PROJECT
                             );
                         }
                     }
-
-                    // grab original python dependency version from [tool.poetry.dependencies]
-                    Optional<Config> poetryDependenciesGroup = tomlFileConfig.getOptional(TomlUtils.TOOL_POETRY_DEPENDENCIES);
-                    if (poetryDependenciesGroup.isPresent()) {
-                        Config poetryDependenciesGroupEntry = poetryDependenciesGroup.get();
-                        if (poetryDependenciesGroupEntry.contains(TomlUtils.PYTHON)) {
-                            pythonDependencyVersion = poetryDependenciesGroupEntry.get(TomlUtils.PYTHON);
-                            if (pythonDependencyVersion.contains(TomlUtils.CARROT)) {
-                                pythonDependencyVersion = TomlUtils.refactorCarrotIntoGreaterThanLessThan(pythonDependencyVersion);
-                            }
-                        }
-                    }
                 }
             }
         }
-
-        return shouldExecute;
+        return missingRequiresPython || updateFaultyFormat || (!missingRequiresPython && hasPoetryPython);
     }
 
     @Override
     protected boolean performMigration(File pyProjectTomlFile) {
-        boolean inProjectSection = false;
-        boolean inPoetryDependenciesSection = false;
-        boolean injectedRequiresPython = false;
         boolean injectAfterNextEmptyLine = false;
-        boolean correctedRequiresPython = false;
         String requiresPythonLine = TomlUtils.REQUIRES_PYTHON + " " + TomlUtils.EQUALS + " " + TomlUtils.DOUBLE_QUOTE + pythonDependencyVersion + TomlUtils.DOUBLE_QUOTE;
         StringBuilder fileContent = new StringBuilder();
+        String currentSection = null;
 
         try (BufferedReader reader = new BufferedReader(new FileReader(pyProjectTomlFile))){
             String line = reader.readLine();
@@ -87,43 +95,51 @@ public class PoetryToProjectRequiresPythonMigration extends AbstractPoetryMigrat
                 String trimmedLine = line.strip();
 
                 if (trimmedLine.startsWith("[") && trimmedLine.endsWith("]")){
-                    if(trimmedLine.equals("[" + TomlUtils.PROJECT + "]")){
-                        inProjectSection = true;
-                        inPoetryDependenciesSection = false;
-                    } else if (trimmedLine.equals("[" + TomlUtils.TOOL_POETRY_DEPENDENCIES + "]")){
-                        inProjectSection = false;
-                        inPoetryDependenciesSection = true;
-                    } else {
-                        inProjectSection = false;
-                        inPoetryDependenciesSection = false;
-                    }
+                    currentSection = trimmedLine.substring(1, trimmedLine.length()-1);
                 }
                 if (trimmedLine.contains(TomlUtils.EQUALS)) {
-                    if (inPoetryDependenciesSection) {
+                    if (TomlUtils.TOOL_POETRY_DEPENDENCIES.equals(currentSection) && hasPoetryPython) {
                         // If in the [tool.poetry.dependencies] section, skip the line that defines the python dependency
-                        // considers cases where there are other dependencies whose name starts with 'python'
                         int equalIndex = trimmedLine.indexOf(TomlUtils.EQUALS);
                         String key = trimmedLine.substring(0, equalIndex).strip();
 
                         // Only skip the line if the key exactly matches "python"
                         if (key.equalsIgnoreCase(TomlUtils.PYTHON)) {
                             addLine = false;
+                            hasPoetryPython = false;
                         }
-                    } else if (inProjectSection) {
-                        if (updateFaultyFormat && trimmedLine.contains(TomlUtils.REQUIRES_PYTHON) && !correctedRequiresPython) {
+
+                    } else if (TomlUtils.PROJECT.equals(currentSection)) {
+                        if (updateFaultyFormat && trimmedLine.contains(TomlUtils.REQUIRES_PYTHON)){
                             // Update the faulty formatted "requires-python" line to use greater-than or less-than notation
                             addLine = false;
                             fileContent.append(requiresPythonLine).append("\n");
-                            correctedRequiresPython = true;
-                        } else if (!updateFaultyFormat && !injectedRequiresPython) {
+                            updateFaultyFormat = false;
+                        } else if (missingRequiresPython){
                             // Otherwise inject the missing "requires-python" line
                             injectAfterNextEmptyLine = true;
+                            missingRequiresPython = false;
                         }
+                    } else if (TomlUtils.TOOL_POETRY.equals(currentSection) && hasInlineDependenciesTable && trimmedLine.contains(TomlUtils.DEPENDENCIES)){
+                        addLine = false;
+
+                        // Only need to remove python if other dependencies exist, otherwise we can just skip the line
+                        if (poetryDependenciesKeys.size() > 1){
+                            String regex;
+                            if(poetryDependenciesKeys.indexOf(TomlUtils.PYTHON) == poetryDependenciesKeys.size()-1){
+                                // if python is the last element, we drop the preceding comma + python entry
+                                regex = TomlUtils.COMMA_PATTERN.pattern() + TomlUtils.PYTHON_DEPENDENCIES_PATTERN.pattern();
+                            } else {
+                                // otherwise, we drop the python entry + trailing comma
+                                regex = TomlUtils.PYTHON_DEPENDENCIES_PATTERN.pattern() + TomlUtils.COMMA_PATTERN.pattern();
+                            }
+                            fileContent.append(trimmedLine.replaceAll(regex, "")).append("\n");
+                        }
+                        hasInlineDependenciesTable = false;
                     }
                 }
                 if (isEmptyLine && injectAfterNextEmptyLine ) {
                     fileContent.append(requiresPythonLine).append("\n");
-                    injectedRequiresPython = true;
                     injectAfterNextEmptyLine = false;
                 }
 

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/util/TomlUtils.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/util/TomlUtils.java
@@ -49,8 +49,8 @@ public final class TomlUtils {
     public static final String DOT = ".";
     public static final String DOT_REGEX = "\\.";
     public static final String PYPROJECT_TOML = "pyproject.toml";
-    public static final String CARROT = "^";
-    public static final String CARROT_REGEX = "\\^";
+    public static final String CARET = "^";
+    public static final String CARET_REGEX = "\\^";
     public static final String GREATER_THAN = ">";
     public static final String GREATER_THAN_OR_EQUAL_TO = ">=";
     public static final String COMMA = ",";
@@ -79,7 +79,20 @@ public final class TomlUtils {
      * e.g. "[a.b]" or "[[a.b]]", capturing the text between the brackets
      * as group 1 (the full section name without surrounding '[' or ']').
      */
-    private static final String TOML_SECTION_HEADER_REGEX = "^\\[+(.+?)\\]+$";
+    private static final Pattern TOML_SECTION_HEADER_PATTERN = Pattern.compile("^\\[+(.+?)\\]+$");
+
+    /**
+     * Matches an inline Python dependency assignment in a TOML table
+     * using single/double quotes, and with optional whitespaces
+     * e.g. `python = ">=3.12.0,<4"`, `python='^3.12'`
+     */
+    public static final Pattern PYTHON_DEPENDENCIES_PATTERN = Pattern.compile("\\bpython\\s*=\\s*('|\").*?('|\")");
+
+    /**
+     * Matches a single comma with optional whitespaces
+     * e.g. `, ` and ` ,`
+     */
+    public static final Pattern COMMA_PATTERN = Pattern.compile("\\s*,\\s*");
 
 
     protected TomlUtils() {
@@ -332,8 +345,8 @@ public final class TomlUtils {
      * @param semver the initial semantic version using a "^"
      * @return the adjusted semantic version using ">=" and "<"
      */
-    public static String refactorCarrotIntoGreaterThanLessThan(String semver) {
-        String[] carrotSplit = semver.split(CARROT_REGEX);
+    public static String refactorCaretIntoGreaterThanLessThan(String semver) {
+        String[] carrotSplit = semver.split(CARET_REGEX);
         String semverNoComparator = carrotSplit[1];
 
         Integer nextMajorSemver;
@@ -394,12 +407,11 @@ public final class TomlUtils {
      * @return      a list of section names without surrounding brackets
      */
     public static List<String> extractTomlSectionHeaders(File file){
-        Pattern headerPattern = Pattern.compile(TOML_SECTION_HEADER_REGEX);
         List<String> sectionHeadersList = new ArrayList<>();
         try(BufferedReader reader = new BufferedReader(new FileReader(file))){
             String line = reader.readLine();
             while (line != null){
-                Matcher m = headerPattern.matcher(line.strip());
+                Matcher m = TOML_SECTION_HEADER_PATTERN.matcher(line.strip());
                 if (m.matches()) {
                     sectionHeadersList.add(m.group(1));
                 }

--- a/habushu-maven-plugin/src/main/resources/migrations.json
+++ b/habushu-maven-plugin/src/main/resources/migrations.json
@@ -87,9 +87,6 @@
           {
             "includes": [
               "pyproject.toml"
-            ],
-            "excludes": [
-              "**/examples/poetry/habushu-poetry-install-from-dev-repo/pyproject.toml"
             ]
           }
         ]

--- a/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryToProjectRequiresPythonMigrationSteps.java
+++ b/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryToProjectRequiresPythonMigrationSteps.java
@@ -44,6 +44,43 @@ public class PoetryToProjectRequiresPythonMigrationSteps extends AbstractPoetryM
         assertKeyExists(projectEntries, TomlUtils.REQUIRES_PYTHON, false);
     }
 
+    @Given("an existing pyproject.toml file with an inline dependencies table with only python and no requires-python entry in the project group")
+    public void an_existing_pyproject_toml_file_with_inline_dependencies_table_and_no_requires_python_entry_in_project_group() {
+        pyProjectToml = new File(testTomlFileDirectory, "with-only-python-in-inline-deps-table-and-no-requires-python-in-project.toml");
+        Config projectEntries = loadAndAssertGroupExists(TomlUtils.PROJECT);
+        assertKeyExists(projectEntries, TomlUtils.REQUIRES_PYTHON, false);
+        Config toolPoetryDepsEntries = loadAndAssertGroupExists(TomlUtils.TOOL_POETRY_DEPENDENCIES);
+        assertKeyExists(toolPoetryDepsEntries, TomlUtils.PYTHON, true);
+    }
+
+    @Given("an existing pyproject.toml file with an inline dependencies table with multiple entries and no requires-python entry in the project group")
+    public void an_existing_pyproject_toml_file_with_inline_dependencies_table_with_multiple_entries_and_no_requires_python_entry_in_project_group(){
+        pyProjectToml = new File(testTomlFileDirectory, "with-inline-deps-table-and-no-requires-python-in-project.toml");
+        Config projectEntries = loadAndAssertGroupExists(TomlUtils.PROJECT);
+        assertKeyExists(projectEntries, TomlUtils.REQUIRES_PYTHON, false);
+        Config toolPoetryEntries = loadAndAssertGroupExists(TomlUtils.TOOL_POETRY_DEPENDENCIES);
+        assertKeyExists(toolPoetryEntries, TomlUtils.PYTHON, true);
+    }
+
+    @Given("an existing pyproject.toml file with an inline dependencies table with multiple entries and a requires-python entry in the project group")
+    public void an_existing_pyproject_toml_file_with_inline_dependencies_table_with_multiple_entries_and_a_requires_python_entry_in_project_group(){
+        pyProjectToml = new File(testTomlFileDirectory, "with-inline-deps-table-and-a-requires-python-in-project.toml");
+        Config projectEntries = loadAndAssertGroupExists(TomlUtils.PROJECT);
+        assertKeyExists(projectEntries, TomlUtils.REQUIRES_PYTHON, true);
+        Config toolPoetryEntries = loadAndAssertGroupExists(TomlUtils.TOOL_POETRY_DEPENDENCIES);
+        assertKeyExists(toolPoetryEntries, TomlUtils.PYTHON, true);
+    }
+
+    @Given("an existing pyproject.toml file with an inline dependencies table with only python and a requires-python entry in the project group")
+    public void an_existing_pyproject_toml_file_with_inline_dependencies_table_with_only_python_and_a_requires_python_entry_in_project_group(){
+        pyProjectToml = new File(testTomlFileDirectory, "with-only-python-in-inline-deps-table-and-a-requires-python-in-project.toml");
+        Config projectEntries = loadAndAssertGroupExists(TomlUtils.PROJECT);
+        assertKeyExists(projectEntries, TomlUtils.REQUIRES_PYTHON, true);
+        Config toolPoetryEntries = loadAndAssertGroupExists(TomlUtils.TOOL_POETRY_DEPENDENCIES);
+        assertKeyExists(toolPoetryEntries, TomlUtils.PYTHON, true);
+    }
+
+
     @When("the Habushu poetry-to-project-requires-python migration executes")
     public void the_habushu_poetry_to_project_requires_python_migration_executes() {
         PoetryToProjectRequiresPythonMigration migration = new PoetryToProjectRequiresPythonMigration();
@@ -72,5 +109,18 @@ public class PoetryToProjectRequiresPythonMigrationSteps extends AbstractPoetryM
     @Then("the poetry to project requires python migration did not execute")
     public void the_poetry_to_project_requires_python_migration_did_not_execute() {
         assertFalse(shouldExecute, "Migration execution should have been skipped!");
+    }
+
+    @Then("the dependencies inline table no longer exists in the tool.poetry group")
+    public void the_dependencies_inline_table_no_longer_exists_in_tool_poetry_group(){
+        Config toolPoetryEntries = loadAndAssertGroupExists(TomlUtils.TOOL_POETRY);
+        assertKeyExists(toolPoetryEntries, TomlUtils.DEPENDENCIES, false);
+    }
+
+    @Then("python is removed from the dependencies inline table in the tool.poetry group")
+    public void python_is_removed_from_dependencies_inline_table_in_tool_poetry_group(){
+        assertGroupExists(TomlUtils.TOOL_POETRY);
+        Config toolPoetryDepsEntries = loadAndAssertGroupExists(TomlUtils.TOOL_POETRY_DEPENDENCIES);
+        assertKeyExists(toolPoetryDepsEntries, TomlUtils.PYTHON, false);
     }
 }

--- a/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-inline-deps-table-and-a-requires-python-in-project.toml
+++ b/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-inline-deps-table-and-a-requires-python-in-project.toml
@@ -1,0 +1,19 @@
+[project]
+name = "with-inline-deps-table-and-a-requires-python-in-project"
+description = "Test running the poetry-to-project-requires-python migration when Poetry version is at least 2.0.0, toml file has inline dependencies table, and already has project.requires-python"
+version = "2.9.0.dev"
+authors = [{name = "Test", email = "blah@foobar.com"}]
+maintainers = [{name = "Test", email = "blah@foobar.com"}]
+license = "MIT License"
+requires-python = ">=3.11,<4"
+
+[tool.poetry]
+dependencies = {ruff = "^0.11.6", python = "^3.11"}
+readme = "README.md"
+
+[tool.poetry.group.dev.dependencies]
+kappa-maki = ">=1.0.0"
+
+[build-system]
+requires = ["poetry-core>=1.6.0"]
+build-backend = "poetry.core.masonry.api"

--- a/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-inline-deps-table-and-no-requires-python-in-project.toml
+++ b/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-inline-deps-table-and-no-requires-python-in-project.toml
@@ -1,0 +1,18 @@
+[project]
+name = "with-inline-deps-table-and-no-requires-python-in-project"
+description = "Test running the poetry-to-project-requires-python migration when Poetry version is at least 2.0.0 and toml file has inline dependencies table"
+version = "2.9.0.dev"
+authors = [{name = "Test", email = "blah@foobar.com"}]
+maintainers = [{name = "Test", email = "blah@foobar.com"}]
+license = "MIT License"
+
+[tool.poetry]
+dependencies = {ruff = "^0.11.6", python = "^3.11"}
+readme = "README.md"
+
+[tool.poetry.group.dev.dependencies]
+kappa-maki = ">=1.0.0"
+
+[build-system]
+requires = ["poetry-core>=1.6.0"]
+build-backend = "poetry.core.masonry.api"

--- a/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-only-python-in-inline-deps-table-and-a-requires-python-in-project.toml
+++ b/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-only-python-in-inline-deps-table-and-a-requires-python-in-project.toml
@@ -1,0 +1,19 @@
+[project]
+name = "with-only-python-in-inline-deps-table-and-a-requires-python-in-project"
+description = "Test running the poetry-to-project-requires-python migration when Poetry version is at least 2.0.0, toml file has inline dependencies table, and project.requires-python already exists."
+version = "2.9.0.dev"
+authors = [{name = "Test", email = "blah@foobar.com"}]
+maintainers = [{name = "Test", email = "blah@foobar.com"}]
+license = "MIT License"
+requires-python = ">=3.11,4"
+
+[tool.poetry]
+dependencies = {python = "^3.11"}
+readme = "README.md"
+
+[tool.poetry.group.dev.dependencies]
+kappa-maki = ">=1.0.0"
+
+[build-system]
+requires = ["poetry-core>=1.6.0"]
+build-backend = "poetry.core.masonry.api"

--- a/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-only-python-in-inline-deps-table-and-no-requires-python-in-project.toml
+++ b/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-only-python-in-inline-deps-table-and-no-requires-python-in-project.toml
@@ -1,0 +1,18 @@
+[project]
+name = "with-only-python-in-inline-deps-table-and-no-requires-python-in-project"
+description = "Test running the poetry-to-project-requires-python migration when Poetry version is at least 2.0.0 and toml file has inline dependencies table"
+version = "2.9.0.dev"
+authors = [{name = "Test", email = "blah@foobar.com"}]
+maintainers = [{name = "Test", email = "blah@foobar.com"}]
+license = "MIT License"
+
+[tool.poetry]
+dependencies = {python = "^3.11"}
+readme = "README.md"
+
+[tool.poetry.group.dev.dependencies]
+kappa-maki = ">=1.0.0"
+
+[build-system]
+requires = ["poetry-core>=1.6.0"]
+build-backend = "poetry.core.masonry.api"

--- a/habushu-maven-plugin/src/test/resources/specifications/poetry-v2/poetry-to-project-requires-python-migration.feature
+++ b/habushu-maven-plugin/src/test/resources/specifications/poetry-v2/poetry-to-project-requires-python-migration.feature
@@ -8,6 +8,20 @@ Feature: Test automatic migrations of python dependency from [tool.project] to [
     Then the requires-python entry is added to the project group and set to ">=3.11,<4"
     And the python entry no longer exists in the tool.poetry.dependencies group
 
+  Scenario: Poetry version is at least 2.0.0 and the poetry-to-project-requires-python migration adds a new requires-python entry to [project] group and removes dependencies inline table from [tool.poetry] group
+    Given the Poetry version is at least "2.0.0"
+    And an existing pyproject.toml file with an inline dependencies table with only python and no requires-python entry in the project group
+    When the Habushu poetry-to-project-requires-python migration executes
+    Then the requires-python entry is added to the project group and set to ">=3.11,<4"
+    And the dependencies inline table no longer exists in the tool.poetry group
+
+  Scenario: Poetry version is at least 2.0.0 and the poetry-to-project-requires-python migration adds a new requires-python entry to [project] group and removes python from the dependencies inline table from [tool.poetry] group
+    Given the Poetry version is at least "2.0.0"
+    And an existing pyproject.toml file with an inline dependencies table with multiple entries and no requires-python entry in the project group
+    When the Habushu poetry-to-project-requires-python migration executes
+    Then the requires-python entry is added to the project group and set to ">=3.11,<4"
+    And python is removed from the dependencies inline table in the tool.poetry group
+
   Scenario: Poetry version is at least 2.0.0 and project group already has a requires-python entry so the migration does not execute
     Given the Poetry version is at least "2.0.0"
     And an existing pyproject.toml file with a requires-python entry in the project group
@@ -19,6 +33,18 @@ Feature: Test automatic migrations of python dependency from [tool.project] to [
     And an existing pyproject.toml file with a badly formatted requires-python entry in the project group
     When the Habushu poetry-to-project-requires-python migration executes
     Then the requires-python entry is added to the project group and set to ">=3.11,<4"
+
+  Scenario: Poetry version is at least 2.0.0 and removes duplicate python entry from tool.poetry inline dependencies table
+    Given the Poetry version is at least "2.0.0"
+    And an existing pyproject.toml file with an inline dependencies table with multiple entries and a requires-python entry in the project group
+    When the Habushu poetry-to-project-requires-python migration executes
+    And python is removed from the dependencies inline table in the tool.poetry group
+
+  Scenario: Poetry version is at least 2.0.0 and removes entire tool.poetry dependencies inline table
+    Given the Poetry version is at least "2.0.0"
+    And an existing pyproject.toml file with an inline dependencies table with only python and a requires-python entry in the project group
+    When the Habushu poetry-to-project-requires-python migration executes
+    And the dependencies inline table no longer exists in the tool.poetry group
 
   Scenario: Poetry version is less than 2.0.0 so the migration does not execute
     Given the Poetry version is less than "2.0.0"


### PR DESCRIPTION
#361 
For Poetry v2 projects:
- accounts for inline tables when migration `python` version constraint from `tool.poetry.dependencies` to `project.requires-python`
- removes duplicate python dep from `pyproject.toml` if it exists
- deactivates a migration for the `habushu-poetry-install-from-dev-repo` example project