### PR TITLE
[#389] - poetry containerization builder template pipx install fix

### DIFF
--- a/examples/poetry/habushu-poetry-containerize/src/main/resources/docker/Dockerfile
+++ b/examples/poetry/habushu-poetry-containerize/src/main/resources/docker/Dockerfile
@@ -1,9 +1,10 @@
 #HABUSHU_BUILDER_STAGE - HABUSHU GENERATED CODE (DO NOT MODIFY)
 FROM docker.io/python:3.12 AS habushu_builder
+USER root
 
 # Install pipx
 RUN python -m ensurepip --upgrade
-RUN python -m pip install --user pipx
+RUN python -m pip install --force-reinstall --user pipx
 
 # Poetry and supporting plugin installations
 RUN $HOME/.local/bin/pipx install poetry==2.0.1 && \
@@ -13,7 +14,6 @@ WORKDIR /work-dir
 COPY --chown=1001 target/containerize-support ./containerize-support/
 RUN find . -type f -name pyproject.toml -exec sed -i 's|develop[[:blank:]]*=[[:blank:]]*true|develop = false|g' {} \;
 
-USER root
 WORKDIR /work-dir/containerize-support/examples/poetry/habushu-poetry-package-consumer
 ENV POETRY_CACHE_DIR="/.cache/pypoetry"
 

--- a/habushu-maven-plugin/src/main/resources/templates/dockerfile_poetry_builder_stage_template.vm
+++ b/habushu-maven-plugin/src/main/resources/templates/dockerfile_poetry_builder_stage_template.vm
@@ -1,8 +1,9 @@
 FROM $builderBaseImage AS habushu_builder
+USER root
 
 # Install pipx
 RUN python -m ensurepip --upgrade
-RUN python -m pip install --user pipx
+RUN python -m pip install --force-reinstall --user pipx
 
 # Poetry and supporting plugin installations
 RUN $HOME/.local/bin/pipx install poetry==$poetryVersion && \
@@ -12,7 +13,6 @@ WORKDIR /work-dir
 COPY $chownPlaceholder $anchorDirectory ./containerize-support/
 RUN find . -type f -name pyproject.toml -exec sed -i 's|develop[[:blank:]]*=[[:blank:]]*true|develop = false|g' {} \;
 
-USER root
 WORKDIR /work-dir/containerize-support/$singleRepoProjectDir
 ENV POETRY_CACHE_DIR="/.cache/pypoetry"
 


### PR DESCRIPTION
Changing the `habushu_builder` stage so that the entire block is run under the root user and we add a `--force-reinstall` flag to the `pipx` install so that even if the user brings in an image with pipx already installed we will guarantee that the root user has a fresh install located at `$HOME/.local/bin/pipx`