### PR TITLE
[#407] Updated skipPoetryLockUpdate config to be generic

### DIFF
--- a/docs/CONFIGURATION_README.md
+++ b/docs/CONFIGURATION_README.md
@@ -39,7 +39,7 @@ mvn clean install -Dhabushu.pythonVersion=3.12.9
   - [defaultPythonStrategy](#defaultpythonstrategy)
   - [rewriteLocalPathDepsInArchives](#rewritelocalpathdepsinarchives)
   - [forceSync](#forcesync)
-  - [skipPoetryLockUpdate](#skippoetrylockupdate)
+  - [skipLockUpdate](#skiplockupdate)
   - [deleteVirtualEnv](#deletevirtualenv)
   - [skipDeploy](#skipdeploy)
   - [snapshotNumberDateFormatPattern](#snapshotnumberdateformatpattern)
@@ -169,9 +169,9 @@ Default: `false`
 
 **Example:** TODO
 
-### skipPoetryLockUpdate
+### skipLockUpdate
 
-Typically enabled when running CI, this configuration enables skipping the update of Poetry's lock file via `poetry lock`. If `poetry.lock` does not exist, the subsequent execution of `poetry install` will create it regardless of this configuration. If `poetry.lock` has a mismatch with its `pyproject.toml` definition, the build will fail.
+Typically enabled when running CI, this configuration enables skipping the update of Poetry or uv lock file via their `lock` commands. If their lock files does not exist, the subsequent execution of `install` will create it regardless of this configuration. If `poetry.lock` or `uv.lock` have a mismatch with its `pyproject.toml` definition, the build will fail.
 
 Default: `false`
 

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/InstallDependenciesMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/InstallDependenciesMojo.java
@@ -51,8 +51,8 @@ public class InstallDependenciesMojo extends AbstractHabushuMojo {
     /**
      * Configures whether the lock file will be updated before install.
      */
-    @Parameter(defaultValue = "false", property = "habushu.skipPoetryLockUpdate")
-    protected boolean skipPoetryLockUpdate;
+    @Parameter(defaultValue = "false", property = "habushu.skipLockUpdate")
+    protected boolean skipLockUpdate;
 
     /**
      * Specifies groups to include in the installation.
@@ -161,8 +161,8 @@ public class InstallDependenciesMojo extends AbstractHabushuMojo {
      * Get configuration for the path for the simple index on a private pypi repository.
      * @return pypiSimpleSuffix
      */
-    public boolean skipPoetryLockUpdate() {
-        return skipPoetryLockUpdate;
+    public boolean skipLockUpdate() {
+        return skipLockUpdate;
     }
 
     /**

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/InstallDependenciesPoetry.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/InstallDependenciesPoetry.java
@@ -62,10 +62,10 @@ public class InstallDependenciesPoetry extends AbstractInstallDependencies {
             prepareRepositoryForInstallation(installDependenciesMojo.getDevRepositoryId(), installDependenciesMojo.getDevRepositoryUrl(), PYPROJECT_PACKAGE_SOURCES_PATH);
         }
 
-        if (!installDependenciesMojo.skipPoetryLockUpdate()) {
+        if (!installDependenciesMojo.skipLockUpdate()) {
             log.info("Locking dependencies specified in pyproject.toml...");
             poetryHelper.executeAndLogAfterTimeout(
-                    poetryHelper.createLockCommand(installDependenciesMojo.skipPoetryLockUpdate()),
+                    poetryHelper.createLockCommand(installDependenciesMojo.skipLockUpdate()),
                     2,
                     TimeUnit.MINUTES,
                     POETRY_CLEAN_CACHE_COMMAND

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/InstallDependenciesUv.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/InstallDependenciesUv.java
@@ -79,10 +79,10 @@ public class InstallDependenciesUv extends AbstractInstallDependencies {
             prepareRepositoryForInstallation(installDependenciesMojo.getDevRepositoryId(), installDependenciesMojo.getDevRepositoryUrl(), PYPROJECT_PACKAGE_INDEX_PATH);
         }
 
-        if (!installDependenciesMojo.skipPoetryLockUpdate()) {
+        if (!installDependenciesMojo.skipLockUpdate()) {
             log.info("Locking dependencies specified in pyproject.toml...");
             uvAuthenticationHelper.executeLockCommandAndLogAfterTimeout(
-                    installDependenciesMojo.skipPoetryLockUpdate,
+                    installDependenciesMojo.skipLockUpdate,
                     true,
                     2,
                     TimeUnit.MINUTES,

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/exec/PoetryCommandHelper.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/exec/PoetryCommandHelper.java
@@ -238,16 +238,16 @@ public class PoetryCommandHelper extends AbstractCommandHelper {
         return createLockCommand(true);
     }
 
-    public List<String> createLockCommand(boolean skipPoetryLockUpdate) {
+    public List<String> createLockCommand(boolean skipLockUpdate) {
         List<String> arguments = new ArrayList<>();
         arguments.add("lock");
 
         if (isPoetryVersionAtLeastMinimumVersion()) {
-            if (!skipPoetryLockUpdate) {
+            if (!skipLockUpdate) {
                 arguments.add("--regenerate");
             }
         } else {
-            if (skipPoetryLockUpdate) {
+            if (skipLockUpdate) {
                 arguments.add("--no-update");
             }
         }

--- a/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/PoetryCommandHelperSteps.java
+++ b/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/PoetryCommandHelperSteps.java
@@ -33,9 +33,9 @@ public class PoetryCommandHelperSteps {
         assertEquals(expectedResult, isPoetryVersionAtLeast2, "Unexpected Poetry version found.");
     }
 
-    @Given("skipPoetryLockUpdate is {}")
-    public void skip_poetry_lock_update_is(boolean skipPoetryLockUpdate) {
-        testSkipUpdate = skipPoetryLockUpdate;
+    @Given("skipLockUpdate is {}")
+    public void skip_poetry_lock_update_is(boolean skipLockUpdate) {
+        testSkipUpdate = skipLockUpdate;
     }
 
     @When("the lock command is created")

--- a/habushu-maven-plugin/src/test/resources/specifications/poetry-command-helper.feature
+++ b/habushu-maven-plugin/src/test/resources/specifications/poetry-command-helper.feature
@@ -12,16 +12,16 @@ Feature: Test creating Poetry Helper commands based on the given Poetry version
       | 2.0.0         | true           |
       | 2.0.1         | true           |
 
-  Scenario Outline: Create lock command with skipPoetryLockUpdate
+  Scenario Outline: Create lock command with skipLockUpdate
     Given the Poetry version is "<poetryVersion>"
-    And skipPoetryLockUpdate is <skipPoetryLockUpdate>
+    And skipLockUpdate is <skipLockUpdate>
     When the lock command is created
     Then the returned arguments should be:
       | <expectedArg1> |
       | <expectedArg2> |
 
     Examples:
-      | poetryVersion | skipPoetryLockUpdate | expectedArg1 | expectedArg2       |
+      | poetryVersion | skipLockUpdate | expectedArg1 | expectedArg2       |
       | 2.0.0         | true                 | lock         |                    |
       | 2.0.0         | false                | lock         | --regenerate       |
       | 1.6.1         | true                 | lock         | --no-update        |


### PR DESCRIPTION
Configuration is used by both uv and Poetry so updated the name to be more generic.