### PR TITLE
[#423] pull repository handling into class

### DIFF
--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/AbstractHabushuMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/AbstractHabushuMojo.java
@@ -11,6 +11,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.settings.Server;
 import org.apache.maven.settings.Settings;
+import org.codehaus.plexus.util.StringUtils;
 import org.sonatype.plexus.components.cipher.PlexusCipherException;
 import org.sonatype.plexus.components.sec.dispatcher.SecDispatcherException;
 import org.technologybrewery.habushu.exec.CommandHelper;
@@ -20,6 +21,7 @@ import org.technologybrewery.habushu.exec.UvCommandHelper;
 import org.technologybrewery.habushu.util.HabushuUtil;
 import org.technologybrewery.habushu.util.MavenPasswordDecoder;
 import org.technologybrewery.habushu.util.PackageManager;
+import org.technologybrewery.habushu.util.PythonRepository;
 
 /**
  * Contains logic common across the various Habushu mojos.
@@ -79,18 +81,6 @@ public abstract class AbstractHabushuMojo extends AbstractMojo {
 
     /**
      * Specifies the {@code <id>} of the {@code <server>} element declared within
-     * the utilized settings.xml configuration that represents the desired
-     * credentials to use when publishing the package to a dev PyPI repository.
-     */
-    public static final String DEV_PYPI_REPO_ID = "dev-pypi";
-
-    /**
-     * Specifies the default dev pypi url to leverage.
-     */
-    public static final String TEST_PYPI_REPOSITORY_URL = "https://test.pypi.org/";
-
-    /**
-     * Specifies the {@code <id>} of the {@code <server>} element declared within
      * the utilized settings.xml configuration that represents the PyPI repository
      * to which this project's archives will be published and/or used as a supplemental
      * repository from which dependencies may be installed. This property is
@@ -105,7 +95,7 @@ public abstract class AbstractHabushuMojo extends AbstractMojo {
      * {@code <server>} declaration with a matching {@code <id>} as credentials for
      * publishing the package to the official public PyPI repository.
      */
-    @Parameter(property = "habushu.pypiRepoId", defaultValue = HabushuUtil.PUBLIC_PYPI_REPO_ID)
+    @Parameter(property = "habushu.pypiRepoId", defaultValue = PythonRepository.PUBLIC_PYPI_REPO_ID)
     protected String pypiRepoId;
 
     /**
@@ -116,6 +106,34 @@ public abstract class AbstractHabushuMojo extends AbstractMojo {
      */
     @Parameter(property = "habushu.pypiRepoUrl")
     protected String pypiRepoUrl;
+
+    /**
+     * Determines if pypiSimpleSuffix is enabled or not.
+     * Setting enablePypiSimpleSuffix to false will set pypiSimpleSuffix to empty value regardless
+     * of pypiSimpleSuffix property value.
+     * Setting enablePypiSimpleSuffix to true will honor pypiSimpleSuffix property value.
+     */
+    @Parameter(property = "habushu.enablePypiSimpleSuffix", defaultValue = "true")
+    protected boolean enablePypiSimpleSuffix;
+
+    /**
+     * Configures the path for the simple index on a private pypi repository.
+     * Certain private repository solutions (ie: devpi) use different names for the
+     * simple index. devpi, for instance, uses "+simple".
+     */
+    @Parameter(property = "habushu.pypiSimpleSuffix", defaultValue = "simple")
+    protected String pypiSimpleSuffix;
+
+    /**
+     * Allows tailoring of the path used for pushing to a PyPI repository for deployment.  Some repositories, like
+     * Nexus or Artifactory, do not require an url path on top of the base repository url.  Others, do (often using
+     * "legacy/").  This variable allows customization in a manner that does not impact the installation API for the
+     * same repository.  Defaults to empty as the most common scenario when overriding the repository URL is to leverage
+     * one of the repositories mentioned above.
+     * Note: The property must be set equal to "" in order for Maven to not set the default value to null
+     */
+    @Parameter(property = "habushu.pypiUploadSuffix", defaultValue = "")
+    protected String pypiUploadSuffix = "";
 
     /**
      * Instructs deployment to use a development repository rather than a release repository. This is conceptually
@@ -135,14 +153,14 @@ public abstract class AbstractHabushuMojo extends AbstractMojo {
      * dependencies from a devPyPI repository that requires authentication - it is
      * expected that the relevant {@code <server>} element provides the needed
      * authentication details. If this property is *not* specified, this property will
-     * default to {@link #DEV_PYPI_REPO_ID} and the execution of the {@code deploy}
+     * default to {@link PythonRepository#TEST_PYPI_REPO_ID} and the execution of the {@code deploy}
      * lifecycle phase will publish this package to the official public Test PyPI
      * repository. Downstream package publishing functionality (i.e.
      * {@link PublishToPyPiRepoMojo}) will use the relevant settings.xml
      * {@code <server>} declaration with a matching {@code <id>} as credentials for
      * publishing the package to the official public test PyPI repository.
      */
-    @Parameter(property = "habushu.devRepositoryId", defaultValue = DEV_PYPI_REPO_ID)
+    @Parameter(property = "habushu.devRepositoryId", defaultValue = PythonRepository.TEST_PYPI_REPO_ID)
     protected String devRepositoryId;
 
     /**f
@@ -152,8 +170,25 @@ public abstract class AbstractHabushuMojo extends AbstractMojo {
      * to or consuming dependencies from a private PyPI repository.  Should end with a
      * trailing "/".
      */
-    @Parameter(property = "habushu.devRepositoryUrl", defaultValue = TEST_PYPI_REPOSITORY_URL)
+    @Parameter(property = "habushu.devRepositoryUrl", defaultValue = PythonRepository.TEST_PYPI_REPO_URL)
     protected String devRepositoryUrl;
+
+    /**
+     * whether we enable devRepositoryUrlUploadSuffix.
+     * Setting devRepositoryUrlUploadSuffix to false will set devRepositoryUrlUploadSuffix to empty value regardless
+     * of devRepositoryUrlUploadSuffix property value.
+     * Setting devRepositoryUrlUploadSuffix to true will honor devRepositoryUrlUploadSuffix property values.
+     */
+    @Parameter(property = "habushu.enableDevRepositoryUrlUploadSuffix", defaultValue = "true")
+    protected boolean enableDevRepositoryUrlUploadSuffix;
+
+    /**
+     * {{@link #pypiUploadSuffix repositoryUploadSuffix} contains critical information.  The main difference is that
+     * this dev repository url path defaults to "legacy/" as the most common scenario when overriding the dev
+     * repository URL is to leverage test.pypi.org, which needs this configuration.
+     */
+    @Parameter(property = "habushu.devRepositoryUrlUploadSuffix", defaultValue = "legacy/")
+    protected String devRepositoryUrlUploadSuffix;
 
     /**
      * Specifies whether the version of the encapsulated Poetry package should be
@@ -424,6 +459,21 @@ public abstract class AbstractHabushuMojo extends AbstractMojo {
         return pypiRepoUrl;
     }
 
+    public PythonRepository getPypiRepo() {
+        if (StringUtils.isBlank(getPypiRepoUrl())) {
+            return PythonRepository.PUBLIC_PYPI_REPO;
+        }
+
+        PythonRepository repo = new PythonRepository(getPypiRepoId(), getPypiRepoUrl());
+        if (this.enablePypiSimpleSuffix) {
+            repo.setIndexPath(this.pypiSimpleSuffix);
+        } else {
+            repo.setIndexPath(null);
+        }
+        repo.setPublishPath(this.pypiUploadSuffix);
+        return repo;
+    }
+
     /**
      *  Check whether to use dev Repository
      * @return boolean useDevRepository
@@ -446,6 +496,25 @@ public abstract class AbstractHabushuMojo extends AbstractMojo {
      */
     public String getDevRepositoryUrl() {
         return devRepositoryUrl;
+    }
+
+    public PythonRepository getDevRepo() {
+        if (StringUtils.isBlank(getDevRepositoryUrl())) {
+            return PythonRepository.TEST_PYPI_REPO;
+        }
+
+        PythonRepository repo = new PythonRepository(getDevRepositoryId(), getDevRepositoryUrl());
+        if (this.enablePypiSimpleSuffix) {
+            repo.setIndexPath(this.pypiSimpleSuffix);
+        } else {
+            repo.setIndexPath(null);
+        }
+        if (this.enableDevRepositoryUrlUploadSuffix) {
+            repo.setPublishPath(this.devRepositoryUrlUploadSuffix);
+        } else {
+            repo.setPublishPath(null);
+        }
+        return repo;
     }
 
     /**
@@ -472,13 +541,6 @@ public abstract class AbstractHabushuMojo extends AbstractMojo {
      */
     protected File getPyProjectTomlFile() {
         return new File(getPythonProjectBaseDir(), "pyproject.toml");
-    }
-
-    /**
-     * @return TEST_PYPI_REPOSITORY_URL
-     */
-    public String getTestPyPiRepositoryUrl() {
-        return TEST_PYPI_REPOSITORY_URL;
     }
 
     /**

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/AbstractInstallDependencies.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/AbstractInstallDependencies.java
@@ -8,6 +8,8 @@ import org.apache.http.client.utils.URIBuilder;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
 import org.technologybrewery.habushu.util.HabushuUtil;
+import org.technologybrewery.habushu.util.PythonRepository;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -79,6 +81,7 @@ public abstract class AbstractInstallDependencies {
         if (StringUtils.isNotEmpty(repoUrl) && installDependenciesMojo.addPypiRepoAsPackageSources) {
             String pypiRepoSimpleIndexUrl;
             try {
+                //todo: replace with PythonRepository.getIndexUrl
                 pypiRepoSimpleIndexUrl = getPyPiRepoSimpleIndexUrl(repoUrl);
             } catch (URISyntaxException e) {
                 throw new HabushuException(
@@ -102,12 +105,12 @@ public abstract class AbstractInstallDependencies {
                                 LocalDateTime.now(), pypiRepoSimpleIndexUrl),
                         String.format("[[%s]]", packageIndexPath),
                         String.format("name = \"%s\"",
-                                StringUtils.isNotEmpty(repoId) && !HabushuUtil.PUBLIC_PYPI_REPO_ID.equals(repoId)
+                                StringUtils.isNotEmpty(repoId) && !PythonRepository.PUBLIC_PYPI_REPO_ID.equals(repoId)
                                         ? repoId
                                         : "private-pypi-repo"),
                         String.format("url = \"%s\"", pypiRepoSimpleIndexUrl)));
                 if (HabushuUtil.isCurrentPackageManagerUv(getPyProjectTomlFile()) ) {
-                    newPypiRepoSourceConfig.add(String.format("publish-url = \"%s\"", getPublishUrl(repoUrl, !HabushuUtil.PUBLIC_PYPI_REPO_ID.equals(repoId))));
+                    newPypiRepoSourceConfig.add(String.format("publish-url = \"%s\"", getPublishUrl(repoUrl, !PythonRepository.PUBLIC_PYPI_REPO_ID.equals(repoId))));
                 }
 
                 if (shouldAddPriority()){

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/InstallDependenciesMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/InstallDependenciesMojo.java
@@ -32,23 +32,6 @@ public class InstallDependenciesMojo extends AbstractHabushuMojo {
     protected boolean addPypiRepoAsPackageSources;
 
     /**
-     * Determines if pypiSimpleSuffix is enabled or not.
-     * Setting enablePypiSimpleSuffix to false will set pypiSimpleSuffix to empty value regardless
-     * of pypiSimpleSuffix property value.
-     * Setting enablePypiSimpleSuffix to true will honor pypiSimpleSuffix property value.
-     */
-    @Parameter(property = "habushu.enablePypiSimpleSuffix", defaultValue = "true")
-    protected boolean enablePypiSimpleSuffix;
-
-    /**
-     * Configures the path for the simple index on a private pypi repository.
-     * Certain private repository solutions (ie: devpi) use different names for the
-     * simple index. devpi, for instance, uses "+simple".
-     */
-    @Parameter(property = "habushu.pypiSimpleSuffix", defaultValue = "simple")
-    protected String pypiSimpleSuffix;
-
-    /**
      * Configures whether the lock file will be updated before install.
      */
     @Parameter(defaultValue = "false", property = "habushu.skipLockUpdate")
@@ -103,35 +86,6 @@ public class InstallDependenciesMojo extends AbstractHabushuMojo {
      */
     @Parameter(defaultValue = "true", property = "habushu.useInProjectVirtualEnvironment")
     protected boolean useInProjectVirtualEnvironment;
-
-
-    /**
-     * Allows tailoring of the path used for pushing to a PyPI repository for deployment.  Some repositories, like
-     * Nexus or Artifactory, do not require an url path on top of the base repository url.  Others, do (often using
-     * "legacy/").  This variable allows customization in a manner that does not impact the installation API for the
-     * same repository.  Defaults to empty as the most common scenario when overriding the repository URL is to leverage
-     * one of the repositories mentioned above.
-     * Note: The property must be set equal to "" in order for Maven to not set the default value to null
-     */
-    @Parameter(property = "habushu.pypiUploadSuffix", defaultValue = "")
-    protected String pypiUploadSuffix = "";
-
-    /**
-     * Determines whether we enable devRepositoryUrlUploadSuffix.
-     * Setting enableDevRepositoryUrlUploadSuffix to false will set devRepositoryUrlUploadSuffix to empty value regardless
-     * of devRepositoryUrlUploadSuffix property value.
-     * Setting enableDevRepositoryUrlUploadSuffix to true will honor devRepositoryUrlUploadSuffix property values.
-     */
-    @Parameter(property = "habushu.enableDevRepositoryUrlUploadSuffix", defaultValue = "true")
-    protected boolean enableDevRepositoryUrlUploadSuffix;
-
-    /**
-     * {{@link #pypiUploadSuffix repositoryUploadSuffix} contains critical information.  The main difference is that
-     * this dev repository url path defaults to "legacy/" as the most common scenario when overriding the dev
-     * repository URL is to leverage test.pypi.org, which needs this configuration.
-     */
-    @Parameter(property = "habushu.devRepositoryUrlUploadSuffix", defaultValue = "legacy/")
-    protected String devRepositoryUrlUploadSuffix;
 
     /**
      * Get whether a private PyPi repository, is automatically added as a package source

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/InstallDependenciesUv.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/InstallDependenciesUv.java
@@ -8,6 +8,7 @@ import org.apache.maven.plugin.logging.Log;
 import org.codehaus.plexus.util.StringUtils;
 import org.technologybrewery.habushu.exec.UvCommandHelper;
 import org.technologybrewery.habushu.util.HabushuUtil;
+import org.technologybrewery.habushu.util.PythonRepository;
 import org.technologybrewery.habushu.util.TomlReplacementTuple;
 import org.technologybrewery.habushu.util.TomlUtils;
 import org.technologybrewery.habushu.util.VersionExtraTuple;
@@ -113,7 +114,7 @@ public class InstallDependenciesUv extends AbstractInstallDependencies {
                             "# Added by habushu-maven-plugin at %s to use %s as source repository for installing dependencies",
                             LocalDateTime.now(), PUBLIC_PYPI_REPO_URL),
                     String.format("[[%s]]", PYPROJECT_PACKAGE_INDEX_PATH),
-                    String.format("name = \"%s\"", HabushuUtil.PUBLIC_PYPI_REPO_ID),
+                    String.format("name = \"%s\"", PythonRepository.PUBLIC_PYPI_REPO_ID),
                     String.format("url = \"%s\"", PUBLIC_PYPI_REPO_URL),
                     String.format("publish-url = \"%s\"", getPublishUrl(PUBLIC_PYPI_REPO_URL, false)));
 

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/PublishToPyPiRepoMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/PublishToPyPiRepoMojo.java
@@ -66,34 +66,6 @@ public class PublishToPyPiRepoMojo extends AbstractHabushuMojo {
     protected boolean skipDeploy;
 
     /**
-     * Allows tailoring of the path used for pushing to a PyPI repository for deployment.  Some repositories, like
-     * Nexus or Artifactory, do not require an url path on top of the base repository url.  Others, do (often using
-     * "legacy/").  This variable allows customization in a manner that does not impact the installation API for the
-     * same repository.  Defaults to empty as the most common scenario when overriding the repository URL is to leverage
-     * one of the repositories mentioned above.
-     * Note: The property must be set equal to "" in order for Maven to not set the default value to null
-     */
-    @Parameter(property = "habushu.pypiUploadSuffix", defaultValue = "")
-    protected String pypiUploadSuffix = "";
-
-    /**
-     * whether we enable devRepositoryUrlUploadSuffix.
-     * Setting devRepositoryUrlUploadSuffix to false will set devRepositoryUrlUploadSuffix to empty value regardless
-     * of devRepositoryUrlUploadSuffix property value.
-     * Setting devRepositoryUrlUploadSuffix to true will honor devRepositoryUrlUploadSuffix property values.
-     */
-    @Parameter(property = "habushu.enableDevRepositoryUrlUploadSuffix", defaultValue = "true")
-    protected boolean enableDevRepositoryUrlUploadSuffix;
-
-    /**
-     * {{@link #pypiUploadSuffix repositoryUploadSuffix} contains critical information.  The main difference is that
-     * this dev repository url path defaults to "legacy/" as the most common scenario when overriding the dev
-     * repository URL is to leverage test.pypi.org, which needs this configuration.
-     */
-    @Parameter(property = "habushu.devRepositoryUrlUploadSuffix", defaultValue = "legacy/")
-    protected String devRepositoryUrlUploadSuffix;
-
-    /**
      * Specifies the number of times a push to the configured PyPI repository will be attempted before stopping (inclusive
      * of the initial attempt). While this defaults to three and is fully configurable, it can be set to zero to never
      * retry or set to any negative number for unlimited retries.  Unlimited retries will follow a fibonacci backoff

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/PublishToPyPiRepoPoetry.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/PublishToPyPiRepoPoetry.java
@@ -8,6 +8,7 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
 import org.technologybrewery.habushu.exec.PoetryCommandHelper;
 import org.technologybrewery.habushu.util.HabushuUtil;
+import org.technologybrewery.habushu.util.PythonRepository;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -116,7 +117,7 @@ public class PublishToPyPiRepoPoetry extends AbstractPublishToPyPiRepo {
 
             publishToRepoWithCredsArgs = new ArrayList<>();
 
-            if (!HabushuUtil.PUBLIC_PYPI_REPO_ID.equals(repoId)) {
+            if (!PythonRepository.PUBLIC_PYPI_REPO_ID.equals(repoId)) {
                 publishToRepoWithCredsArgs.add(new ImmutablePair<>("--repository", false));
                 publishToRepoWithCredsArgs.add(new ImmutablePair<>(repoId, false));
             }
@@ -141,7 +142,7 @@ public class PublishToPyPiRepoPoetry extends AbstractPublishToPyPiRepo {
         } else {
             log.warn(String.format(
                     "PyPI repository credentials not specified in <server> element in settings.xml with <id> of %s",
-                    HabushuUtil.PUBLIC_PYPI_REPO_ID));
+                    PythonRepository.PUBLIC_PYPI_REPO_ID));
             log.warn(
                     "Please populate settings.xml with PyPI credentials or ensure that Poetry is manually " +
                             "configured with the correct PyPI credentials (i.e. poetry config pypi-token.pypi my-token)");

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/PublishToPyPiRepoUv.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/PublishToPyPiRepoUv.java
@@ -8,6 +8,7 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
 import org.technologybrewery.habushu.exec.UvCommandHelper;
 import org.technologybrewery.habushu.util.HabushuUtil;
+import org.technologybrewery.habushu.util.PythonRepository;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -119,7 +120,7 @@ public class PublishToPyPiRepoUv extends AbstractPublishToPyPiRepo {
             //When publishing locally, uv will throw error if file name is same but hash is different which fails case of -dev0 https://github.com/astral-sh/uv/issues/7917#issuecomment-2495160227
             publishToRepoWithCredsArgs.add(new ImmutablePair<>("./dist/*" + version + "*.tar.gz" , false));
             publishToRepoWithCredsArgs.add(new ImmutablePair<>("./dist/*" + version + "*.whl" , false));
-            if (!HabushuUtil.PUBLIC_PYPI_REPO_ID.equals(repoId)) {
+            if (!PythonRepository.PUBLIC_PYPI_REPO_ID.equals(repoId)) {
                 publishToRepoWithCredsArgs.add(new ImmutablePair<>("--index", false));
                 publishToRepoWithCredsArgs.add(new ImmutablePair<>(repoId, false));
             }
@@ -153,7 +154,7 @@ public class PublishToPyPiRepoUv extends AbstractPublishToPyPiRepo {
         } else {
             log.warn(String.format(
                     "PyPI repository credentials not specified in <server> element in settings.xml with <id> of %s",
-                    HabushuUtil.PUBLIC_PYPI_REPO_ID));
+                    PythonRepository.PUBLIC_PYPI_REPO_ID));
             log.warn(
                     "Please populate settings.xml with PyPI credentials or ensure that Poetry is manually " +
                             "configured with the correct PyPI credentials (i.e. poetry config pypi-token.pypi my-token)");

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/ValidatePythonPackageAndDependencyManagerMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/ValidatePythonPackageAndDependencyManagerMojo.java
@@ -12,6 +12,7 @@ import org.technologybrewery.habushu.util.DefaultPythonStrategy;
 import org.technologybrewery.habushu.util.HabushuUtil;
 import org.technologybrewery.habushu.util.PackageManager;
 import org.technologybrewery.habushu.util.PoetryUtil;
+import org.technologybrewery.habushu.util.PythonRepository;
 import org.technologybrewery.habushu.util.UvUtil;
 
 
@@ -98,7 +99,8 @@ public class ValidatePythonPackageAndDependencyManagerMojo extends AbstractHabus
 
     private void configurePrivateDevPyPiRepositoryCredentials(PythonPackageAndDependencyManagerSetup pythonPackageAndDependencyManagerSetup) {
         if (useDevRepository) {
-            if (!TEST_PYPI_REPOSITORY_URL.equals(devRepositoryUrl)){
+            //todo: use actual PythonRepository object to account for slight variations in URL representation
+            if (!PythonRepository.TEST_PYPI_REPO_URL.equals(devRepositoryUrl)){
                 String pypiDevRepoIdUsername = findUsernameForServer(devRepositoryId);
                 String pypiDevRepoIdPassword = findPasswordForServer(devRepositoryId);
                 pythonPackageAndDependencyManagerSetup.registerRepositoryToSupportAuthenticatedDependencyResolution(devRepositoryId,
@@ -110,6 +112,8 @@ public class ValidatePythonPackageAndDependencyManagerMojo extends AbstractHabus
     }
 
     private void configurePrivatePyPiRepositoryCredentials(PythonPackageAndDependencyManagerSetup pythonPackageAndDependencyManagerSetup) {
+        //todo: use actual PythonRepository object to account for slight variations in URL representation
+        // e.g. the original logic here does not include a trailing slash, but PythonRepository.PUBLIC_PYPI_REPO_URL does
         if (StringUtils.isNotEmpty(pypiRepoUrl) && !"https://pypi.org".equals(pypiRepoUrl)) {
             String pypiRepoIdUsername = findUsernameForServer(pypiRepoId);
             String pypiRepoIdPassword = findPasswordForServer(pypiRepoId);

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/exec/UvCommandHelper.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/exec/UvCommandHelper.java
@@ -9,6 +9,7 @@ import org.slf4j.event.Level;
 import org.technologybrewery.habushu.AbstractHabushuMojo;
 import org.technologybrewery.habushu.HabushuException;
 import org.technologybrewery.habushu.InstallDependenciesMojo;
+import org.technologybrewery.habushu.util.PythonRepository;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -213,11 +214,14 @@ public class UvCommandHelper extends AbstractCommandHelper {
     private String getRepoId(AbstractHabushuMojo mojo) {
         String repoId = StringUtils.EMPTY;
         if (mojo.isUseDevRepository()) {
-            if (!mojo.getTestPyPiRepositoryUrl().equals(mojo.getDevRepositoryUrl())){
+            //todo: use actual PythonRepository object to account for slight variations in URL representation
+            if (!PythonRepository.TEST_PYPI_REPO_URL.equals(mojo.getDevRepositoryUrl())){
                 repoId = mojo.getDevRepositoryId();
             }
         } else {
-            if (!org.codehaus.plexus.util.StringUtils.isEmpty(mojo.getPypiRepoUrl())) {
+            if (!StringUtils.isEmpty(mojo.getPypiRepoUrl())) {
+                //todo: use actual PythonRepository object to account for slight variations in URL representation
+                // e.g. the original logic here does not include a trailing slash, but PythonRepository.PUBLIC_PYPI_REPO_URL does
                 if (!"https://pypi.org".equals(mojo.getPypiRepoUrl())) {
                     repoId = mojo.getPypiRepoId();
                 }

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/util/HabushuUtil.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/util/HabushuUtil.java
@@ -4,6 +4,7 @@ import com.electronwill.nightconfig.core.file.FileConfig;
 import com.electronwill.nightconfig.core.io.ParsingException;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,14 +47,6 @@ public final class HabushuUtil {
 
     public static final Pattern SEMVER2_PATTERN = Pattern.compile("\\d+\\.\\d+\\.\\d+-(rc|alpha|beta)\\.\\d+$",
             Pattern.CASE_INSENSITIVE);
-
-    /**
-     * Specifies the {@code <id>} of the {@code <server>} element declared within
-     * the utilized settings.xml configuration that represents the desired
-     * credentials to use when publishing the package to the official public PyPI
-     * repository.
-     */
-    public static final String PUBLIC_PYPI_REPO_ID = "pypi";
 
     private HabushuUtil() {
     }
@@ -389,7 +382,7 @@ public final class HabushuUtil {
     }
 
     public static String addTrailingSlash(String inputUrl) {
-        if (StringUtils.isNotBlank(inputUrl) && !StringUtils.endsWith(inputUrl, "/")) {
+        if (StringUtils.isNotBlank(inputUrl) && !Strings.CS.endsWith(inputUrl, "/")) {
             // PEP-0694 likes a trailing slash:
             inputUrl += "/";
         }

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/util/PythonRepository.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/util/PythonRepository.java
@@ -1,0 +1,141 @@
+package org.technologybrewery.habushu.util;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
+import org.apache.http.client.utils.URIBuilder;
+import org.technologybrewery.habushu.HabushuException;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A Python package index, or repository.
+ */
+public class PythonRepository {
+    public static final String SIMPLE_API_PATH = "simple";
+    public static final String PUBLIC_PYPI_REPO_ID = "pypi";
+    public static final String PUBLIC_PYPI_REPO_URL = "https://pypi.org/";
+    public static final PythonRepository PUBLIC_PYPI_REPO = new PythonRepository(PUBLIC_PYPI_REPO_ID, PUBLIC_PYPI_REPO_URL);
+    public static final String TEST_PYPI_REPO_ID = "dev-pypi";
+    public static final String TEST_PYPI_REPO_URL = "https://test.pypi.org/";
+    public static final PythonRepository TEST_PYPI_REPO = new PythonRepository(TEST_PYPI_REPO_ID, TEST_PYPI_REPO_URL, SIMPLE_API_PATH, "legacy");
+
+    private String id;
+    private URI baseUrl;
+    private String indexPath;
+    private String publishPath;
+
+    /**
+     * Constructs a repository with the default paths to adhere to the Simple Repository API. See the
+     * <a href="https://packaging.python.org/en/latest/specifications/simple-repository-api">specification</a> for more
+     * details.
+     * @param id the Maven server ID for this repository
+     * @param baseUrl the base URL of the repository on which the API paths are built
+     */
+    public PythonRepository(String id, String baseUrl) {
+        this(id, baseUrl, SIMPLE_API_PATH, SIMPLE_API_PATH);
+    }
+
+    /**
+     * Constructs a repository with custom paths for package look-up ({@code indexPath}) and package publishing
+     * ({@code publishPath}). Typically, for a PEP-503-compliant repository that serves the Simple Repository API, the
+     * path is "simple/" for both.  However, many repositories use the
+     * <a href="https://docs.pypi.org/api/upload">"Legacy" upload API</a> for package publishing (e.g. test.pypi.org).
+     * For these repositories, the publish path is "legacy/".
+     * @param id the Maven server ID for this repository
+     * @param baseUrl the base URL of the repository on which the API paths are built
+     * @param indexPath the URL path for package look-up
+     * @param publishPath the URL path for package publishing
+     */
+    public PythonRepository(String id, String baseUrl, String indexPath, String publishPath) {
+        try {
+            this.id = id;
+            this.baseUrl = new URI(Strings.CS.removeEnd(baseUrl, "/"));
+            setIndexPath(indexPath);
+            setPublishPath(publishPath);
+        } catch (URISyntaxException e) {
+            throw new HabushuException("Invalid URL for Python repository: " + baseUrl, e);
+        }
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getBaseUrl() {
+        return baseUrl.toString();
+    }
+
+    public void setPublishPath(String publishPath) {
+        this.publishPath = normalizePathPart(publishPath);
+    }
+
+    public void setIndexPath(String indexPath) {
+        this.indexPath = normalizePathPart(indexPath);
+    }
+
+
+    /**
+     * Returns the base URL joined with the index path for this repository, accounting for different input formats for
+     * both (i.e. use or lack of leading/trailing forward slashes). If the base URL already ends with the index path, it
+     * is simply returned after ensuring the slashes are correctly accounted for.
+     *
+     * @return package index URL
+     */
+    public String getIndexUrl() {
+        String indexUrl = appendPathPart(baseUrl, indexPath);
+        return HabushuUtil.addTrailingSlash(indexUrl);
+    }
+
+    /**
+     * Returns the base URL joined with the publish path for this repository, accounting for different input formats for
+     * both (i.e. use or lack of leading/trailing forward slashes). If the base URL already ends with the publish path,
+     * it is simply returned after ensuring the slashes are correctly accounted for.
+     *
+     * @return package index URL
+     */
+    public String getPublishUrl() {
+        String publishUrl = appendPathPart(baseUrl, publishPath);
+        return HabushuUtil.addTrailingSlash(publishUrl);
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (!(o instanceof PythonRepository)) {
+            return false;
+        }
+
+        PythonRepository that = (PythonRepository) o;
+        return baseUrl.equals(that.baseUrl);
+    }
+
+    @Override
+    public int hashCode() {
+        return baseUrl.hashCode();
+    }
+
+    private static String normalizePathPart(String pathPart) {
+        pathPart = Strings.CS.removeStart(pathPart, "/");
+        pathPart = Strings.CS.removeEnd(pathPart, "/");
+        return pathPart;
+    }
+
+    private static String appendPathPart(URI base, String pathPart) {
+        URIBuilder pypiRepoUriBuilder = new URIBuilder(base);
+        List<String> repoUriPathSegments = pypiRepoUriBuilder.getPathSegments();
+        String lastPathSegment = CollectionUtils.isNotEmpty(repoUriPathSegments)
+                ? repoUriPathSegments.get(repoUriPathSegments.size() - 1)
+                : null;
+        if (StringUtils.isNotEmpty(pathPart) && !pathPart.equals(lastPathSegment)) {
+            // If the URL has no path, an unmodifiable Collections.emptyList() is returned,
+            // so wrap in an ArrayList to enable later modifications
+            repoUriPathSegments = new ArrayList<>(repoUriPathSegments);
+            repoUriPathSegments.add(pathPart);
+            pypiRepoUriBuilder.setPathSegments(repoUriPathSegments);
+        }
+        return pypiRepoUriBuilder.toString();
+    }
+}

--- a/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/PythonRepositorySteps.java
+++ b/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/PythonRepositorySteps.java
@@ -1,0 +1,68 @@
+package org.technologybrewery.habushu;
+
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.junit.jupiter.api.Assertions;
+import org.technologybrewery.habushu.util.PythonRepository;
+
+public class PythonRepositorySteps {
+    private PythonRepository repository;
+    private PythonRepository anotherRepository;
+
+    @Given("a repository URL of {string}")
+    public void aRepositoryURLOf(String baseUrl) {
+        repository = new PythonRepository("test-repo", baseUrl);
+    }
+
+    @Given("a search index path of {string}")
+    public void aSearchIndexPathOf(String indexPath) {
+        if (!"null".equals(indexPath)) {
+            repository.setIndexPath(indexPath);
+        } else {
+            repository.setIndexPath(null);
+        }
+    }
+
+    @Given("a publish path of {string}")
+    public void aPublishPathOf(String publishPath) {
+        if (!"null".equals(publishPath)) {
+            repository.setPublishPath(publishPath);
+        } else {
+            repository.setPublishPath(null);
+        }
+    }
+
+    @Given("another repository with {string}, {string}, and {string}")
+    public void anotherRepositoryWithAnd(String baseUrl, String indexPath, String publishPath) {
+        anotherRepository = new PythonRepository("another-test-repo", baseUrl, indexPath, publishPath);
+    }
+
+    @When("a repository is created")
+    public void aRepositoryIsCreated() {
+        // nothing to do
+    }
+
+    @When("the repositories are compared")
+    public void theRepositoriesAreCompared() {
+        // nothing to do
+    }
+
+    @Then("the search index URL is {string}")
+    public void theSearchIndexUrlIs(String expectedUrl) {
+        String actualUrl = repository.getIndexUrl();
+        Assertions.assertEquals(expectedUrl, actualUrl, "Search Index URL constructed incorrectly");
+    }
+
+    @Then("the publish URL is {string}")
+    public void thePublishUrlIs(String expectedUrl) {
+        String actualUrl = repository.getPublishUrl();
+        Assertions.assertEquals(expectedUrl, actualUrl, "Publishing URL constructed incorrectly");
+    }
+
+    @Then("they are equal")
+    public void theyAreEqual() {
+        Assertions.assertEquals(repository, anotherRepository, "Repositories are not equal");
+        Assertions.assertEquals(repository.hashCode(), anotherRepository.hashCode(), "Repositories have different hash codes");
+    }
+}

--- a/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/TestInstallDependenciesMojo.java
+++ b/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/TestInstallDependenciesMojo.java
@@ -1,6 +1,7 @@
 package org.technologybrewery.habushu;
 
 import org.technologybrewery.habushu.util.HabushuUtil;
+import org.technologybrewery.habushu.util.PythonRepository;
 
 import java.io.File;
 import java.net.URISyntaxException;
@@ -14,10 +15,10 @@ public class TestInstallDependenciesMojo extends InstallDependenciesMojo {
         super();
 
         //mimic defaults in Mojo:
-        this.pypiRepoId = HabushuUtil.PUBLIC_PYPI_REPO_ID;
+        this.pypiRepoId = PythonRepository.PUBLIC_PYPI_REPO_ID;
         this.useDevRepository = false;
-        this.devRepositoryId = DEV_PYPI_REPO_ID;
-        this.devRepositoryUrl = TEST_PYPI_REPOSITORY_URL;
+        this.devRepositoryId = PythonRepository.TEST_PYPI_REPO_ID;
+        this.devRepositoryUrl = PythonRepository.TEST_PYPI_REPO_URL;
 
         this.enablePypiSimpleSuffix = true;
         this.pypiSimpleSuffix = "simple";

--- a/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/TestPublishToPyPiRepoMojo.java
+++ b/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/TestPublishToPyPiRepoMojo.java
@@ -1,6 +1,7 @@
 package org.technologybrewery.habushu;
 
 import org.technologybrewery.habushu.util.HabushuUtil;
+import org.technologybrewery.habushu.util.PythonRepository;
 
 import java.io.File;
 
@@ -13,10 +14,10 @@ public class TestPublishToPyPiRepoMojo extends PublishToPyPiRepoMojo {
         super();
 
         //mimic defaults in Mojo:
-        this.pypiRepoId = HabushuUtil.PUBLIC_PYPI_REPO_ID;
+        this.pypiRepoId = PythonRepository.PUBLIC_PYPI_REPO_ID;
         this.useDevRepository = false;
-        this.devRepositoryId = DEV_PYPI_REPO_ID;
-        this.devRepositoryUrl = TEST_PYPI_REPOSITORY_URL;
+        this.devRepositoryId = PythonRepository.TEST_PYPI_REPO_ID;
+        this.devRepositoryUrl = PythonRepository.TEST_PYPI_REPO_URL;
 
         this.skipDeploy = false;
         this.pypiUploadSuffix = "";

--- a/habushu-maven-plugin/src/test/resources/specifications/python-repository.feature
+++ b/habushu-maven-plugin/src/test/resources/specifications/python-repository.feature
@@ -1,0 +1,51 @@
+@repositoryHandling
+Feature: Python Repository handling
+
+  Scenario: Default repository urls
+    Given a repository URL of "https://myrepo.org"
+    Then the search index URL is "https://myrepo.org/simple/"
+    Then the publish URL is "https://myrepo.org/simple/"
+
+  Scenario Outline: Repository search index URL
+    Given a repository URL of "<baseUrl>"
+    And a search index path of "<index>"
+    Then the search index URL is "<url>"
+
+    Examples:
+      | baseUrl               | index    | url                          |
+      | https://pvt-repo.org  | search   | https://pvt-repo.org/search/ |
+      | https://pvt-repo.org/ | search   | https://pvt-repo.org/search/ |
+      | https://pvt-repo.org  | search/  | https://pvt-repo.org/search/ |
+      | https://pvt-repo.org/ | /search/ | https://pvt-repo.org/search/ |
+      | https://pvt-repo.org  |          | https://pvt-repo.org/        |
+      | https://pvt-repo.org/ |          | https://pvt-repo.org/        |
+      | https://pvt-repo.org  | null     | https://pvt-repo.org/        |
+
+  Scenario Outline: Repository publish URL
+    Given a repository URL of "<baseUrl>"
+    And a publish path of "<publish>"
+    Then the publish URL is "<url>"
+
+    Examples:
+      | baseUrl               | publish  | url                          |
+      | https://pvt-repo.org  | upload   | https://pvt-repo.org/upload/ |
+      | https://pvt-repo.org/ | upload   | https://pvt-repo.org/upload/ |
+      | https://pvt-repo.org  | upload/  | https://pvt-repo.org/upload/ |
+      | https://pvt-repo.org/ | /upload/ | https://pvt-repo.org/upload/ |
+      | https://pvt-repo.org  |          | https://pvt-repo.org/        |
+      | https://pvt-repo.org/ |          | https://pvt-repo.org/        |
+      | https://pvt-repo.org  | null     | https://pvt-repo.org/        |
+
+  Scenario Outline: Equality
+    Given a repository URL of "<baseUrl1>"
+    And a search index path of "<index1>"
+    And a publish path of "<publish1>"
+    And another repository with "<baseUrl2>", "<index2>", and "<publish2>"
+    Then they are equal
+
+    Examples:
+      | baseUrl1              | index1 | publish1 | baseUrl2              | index2 | publish2 |
+      | https://pvt-repo.org  | search | upload   | https://pvt-repo.org  | search | upload   |
+      | https://pvt-repo.org/ | search | upload   | https://pvt-repo.org  | simple | legacy   |
+      | https://pvt-repo.org  |        | null     | https://pvt-repo.org/ | search | upload   |
+      


### PR DESCRIPTION
Pulls logic for constructing the package index and publishing URLs for a given python repository into a dedicated class.  Also moves some shared parameters for controlling repos into the parent Mojo.  There are some places where the new class could have been used, but to limit the scope of this change, that will be left for future work.