### PR TITLE
[437] fix poetry 2 migration

### DIFF
--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryToProjectMigration.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/migration/poetryv2migrations/PoetryToProjectMigration.java
@@ -5,7 +5,7 @@ import com.electronwill.nightconfig.core.file.FileConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.technologybrewery.baton.BatonException;
-import org.technologybrewery.habushu.util.TomlReplacementTuple;
+import org.technologybrewery.habushu.util.TomlLocationBlock;
 import org.technologybrewery.habushu.util.TomlUtils;
 
 import java.io.BufferedReader;
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.HashMap;
 
 /**
  * Provides functionality to migrate configuration entries from the [tool.poetry] section to the [project] section of a TOML file.
@@ -26,14 +27,13 @@ import java.util.LinkedHashMap;
  */
 public class PoetryToProjectMigration extends AbstractPoetryMigration {
     private static final Logger logger = LoggerFactory.getLogger(PoetryToProjectMigration.class);
-    private boolean hasProjectGroup = false;
-    private final List<String> entriesToMigrate = Arrays.asList("name", "description", "version", "authors", "maintainers", "license");
-    private final List<String> existingProjectKeys = new ArrayList<>();
-    private final Map<String, TomlReplacementTuple> replacements = new LinkedHashMap<>();
+    public static final String PROJECT_SECTION_WITH_BRACKETS = "[" + TomlUtils.PROJECT + "]";
+    public static final String NO_SECTION_HEADER = "no_section_header";
+    private final List<String> entriesToMigrate = Arrays.asList("name", "description", "version", "license");
+    private final Map<String, List<String>> tomlMap = new LinkedHashMap<>();
 
     @Override
     protected boolean shouldExecuteOnFile(File file) {
-        replacements.clear();
         boolean shouldExecute = false;
         Config.setInsertionOrderPreserved(true);
 
@@ -48,33 +48,10 @@ public class PoetryToProjectMigration extends AbstractPoetryMigration {
 
                         // check if any of the entries under [tool.poetry] match one of "name", "description", or "version"
                         String groupEntryName = groupEntry.getKey();
-                        Object groupEntryRhs = groupEntry.getValue();
-                        String groupEntryRhsAsString = null;
 
                         if (entriesToMigrate.stream().anyMatch(e -> e.equalsIgnoreCase(groupEntryName))) {
-                            if (groupEntryRhs instanceof List<?>){
-                                List<String> listValues = poetryGroup.get(groupEntryName);
-                                List<String> listOfStrings = new ArrayList<>(listValues);
-                                groupEntryRhsAsString = convertListOfStringsToString(listOfStrings);
-                            } else {
-                                groupEntryRhsAsString = (String) groupEntryRhs;
-                            }
-
-                            logger.info("Found [{}] group entry to migrate! ({} = {})", TomlUtils.TOOL_POETRY, groupEntryName, groupEntryRhsAsString);
-                            TomlReplacementTuple replacementTuple = new TomlReplacementTuple(groupEntryName, groupEntryRhsAsString, "");
-                            replacements.put(groupEntryName, replacementTuple);
                             shouldExecute = true;
                         }
-                    }
-                }
-                // process the [project] section and record existing keys
-                Optional<Config> projectGroupEntries = tomlFileConfig.getOptional(TomlUtils.PROJECT);
-                if (projectGroupEntries.isPresent()){
-                    hasProjectGroup = true;
-                    Config projectConfig = projectGroupEntries.get();
-                    // iterate over the entries and add each key to the set
-                    for (Config.Entry entry : projectConfig.entrySet()) {
-                        existingProjectKeys.add(entry.getKey());
                     }
                 }
             }
@@ -84,61 +61,64 @@ public class PoetryToProjectMigration extends AbstractPoetryMigration {
 
     @Override
     protected boolean performMigration(File pyProjectTomlFile) {
-        boolean injectAfterNextEmptyLine = false;
-        boolean inToolPoetrySection = false;
-        boolean inProjectSection = false;
-        boolean dependenciesInjected = false;
-        StringBuilder fileContent = new StringBuilder();
+        Map<String, TomlLocationBlock> multiLineProperties = findMultilineProperties(pyProjectTomlFile);
 
         try (BufferedReader reader = new BufferedReader(new FileReader(pyProjectTomlFile))) {
-            String line = reader.readLine();
+            loadTomlFileToMap(reader, multiLineProperties);
 
+            StringBuilder fileContent = generateNewTomlFileContentsFromUpdatedStructure();
+
+            TomlUtils.writeTomlFile(pyProjectTomlFile, fileContent.toString());
+        } catch (IOException e) {
+            throw new BatonException("Problem reading pyproject.toml for migration!", e);
+        }
+
+        return true;
+    }
+
+    public Map<String, TomlLocationBlock> findMultilineProperties(File pyProjectTomlFile) {
+        /*
+         * Parses the Toml file and identifies where items are represented on multiple lines.
+         * If an item is multi-line, the start and end locations are determined and added
+         * to a list.
+         */
+        Map<String, TomlLocationBlock> multiLineProperties = new HashMap<>();
+        try (BufferedReader reader = new BufferedReader(new FileReader(pyProjectTomlFile))) {
+            boolean inArray = false;
+            String currentSection = null;
+            String currentName = null;
+            int startLine = -1;
+
+            String line = reader.readLine();
+            int lineCount = 1;
             while (line != null) {
-                boolean addLine = true;
-                boolean isEmptyLine = line.isBlank();
                 String trimmedLine = line.strip();
 
                 if (trimmedLine.startsWith("[") && trimmedLine.endsWith("]")){
-                    if (trimmedLine.equals("[" + TomlUtils.TOOL_POETRY + "]")) {
-                        inToolPoetrySection = true;
-                        inProjectSection = false;
-                    } else if (trimmedLine.equals(("[" + TomlUtils.PROJECT + "]"))) {
-                        inToolPoetrySection = false;
-                        inProjectSection = true;
-                    } else {
-                        inToolPoetrySection = false;
-                        inProjectSection = false;
-                    }
+                    currentSection = trimmedLine.replaceAll(" ", "");
                 }
-                if (trimmedLine.contains(TomlUtils.EQUALS)) {
-                    if (inToolPoetrySection) {
-                        String key = line.substring(0, line.indexOf(TomlUtils.EQUALS)).strip();
-                        TomlReplacementTuple matchedTuple = replacements.get(key);
-                        if (matchedTuple != null) {
-                            // skip this line, we will add it back to [project] later
-                            addLine = false;
+
+                if (!inArray) {
+                    if (trimmedLine.matches("^[a-zA-Z0-9_.-]+\\s*=\\s*\\[$")) {
+                        // matches lines like the following:
+                        // packages = [
+                        inArray = true;
+                        currentName = getKeyFromLine(trimmedLine);
+                        startLine = lineCount;
+                    }
+                } else {
+                    if (trimmedLine.equals("]")) {
+                        inArray = false;
+
+                        // We only want to create a location object for items under [tool.poetry]
+                        // and in the list of items we are migrating
+                        if(currentSection.equals("[" + TomlUtils.TOOL_POETRY + "]") && entriesToMigrate.contains(currentName)) {
+                            multiLineProperties.put(currentName, new TomlLocationBlock(currentName, startLine, lineCount));
                         }
                     }
-                    if (!hasProjectGroup || (inProjectSection && !replacements.isEmpty())) {
-                        injectAfterNextEmptyLine = true;
-                    }
                 }
-                if (isEmptyLine && injectAfterNextEmptyLine){
-                    if (hasProjectGroup){
-                        fileContent = injectDependencies(fileContent, existingProjectKeys, replacements);
-                        dependenciesInjected = true;
-                        injectAfterNextEmptyLine = false;
-                    } else if (!dependenciesInjected){
-                        fileContent.append("\n[").append(TomlUtils.PROJECT).append("]\n");
-                        fileContent = injectDependencies(fileContent, existingProjectKeys, replacements);
-                        injectAfterNextEmptyLine = false;
-                        hasProjectGroup = true;
-                        dependenciesInjected = true;
-                    }
-                }
-                if (addLine) {
-                    fileContent.append(line).append("\n");
-                }
+
+                lineCount++;
 
                 line = reader.readLine();
             }
@@ -146,13 +126,212 @@ public class PoetryToProjectMigration extends AbstractPoetryMigration {
             throw new BatonException("Problem reading pyproject.toml for migration!", e);
         }
 
-        try {
-            TomlUtils.writeTomlFile(pyProjectTomlFile, fileContent.toString());
-        } catch (IOException e) {
-            throw new BatonException("Problem writing updated pyproject.toml!", e);
+        return multiLineProperties;
+    }
+
+    /**
+     * Processes the Toml file and performs the migration.
+     * @param reader the toml file being processed
+     * @param multiLineProperties a list of all the items that are multi-line
+     * @throws IOException
+     */
+    private void loadTomlFileToMap(BufferedReader reader, Map<String, TomlLocationBlock> multiLineProperties) throws IOException {
+        String currentSection = new String();
+        String line = reader.readLine();
+        String currentKeyName = null;
+        int lineCount = 1;
+        while (line != null) {
+            String trimmedLine = line.strip();
+
+            if (trimmedLine.startsWith("[") && trimmedLine.endsWith("]")){
+                // Process Section Header
+                currentSection = trimmedLine.replaceAll(" ", "");
+                if(!tomlMap.containsKey(currentSection)) {
+                    tomlMap.put(currentSection, new ArrayList<>());
+                } else if(!currentSection.equals(PROJECT_SECTION_WITH_BRACKETS)) {
+                    // If there is a match on the tomlMap key then we have a
+                    // duplicate section header.  We will just add the duplicate
+                    // section header to the group.
+                    tomlMap.get(trimmedLine).add(line);
+                }
+            } else {
+                if(trimmedLine.contains(TomlUtils.EQUALS)) {
+                    // Section items
+                    currentKeyName = getKeyFromLine(trimmedLine);;
+
+                    if(itemNeedsToBeMigrated(currentKeyName, currentSection)){
+                        ensureProjectSectionExistsInTomlMap();
+                        // check for duplicate
+                        if(!checkIfItemAlreadyExistsInProjectSection(tomlMap.get(PROJECT_SECTION_WITH_BRACKETS), trimmedLine)) {
+                            tomlMap.get(PROJECT_SECTION_WITH_BRACKETS).add(trimmedLine);
+
+                            List<String> additionaLines = checkPropertyForMultilineAdditions(
+                                    reader,
+                                    multiLineProperties,
+                                    currentKeyName,
+                                    lineCount
+                            );
+
+                            tomlMap.get(PROJECT_SECTION_WITH_BRACKETS).addAll(additionaLines);
+                            lineCount += additionaLines.size();
+                        }
+                    } else {
+                        if(currentSection.equals(PROJECT_SECTION_WITH_BRACKETS)) {
+                            // check for duplicate
+                            if (!checkIfItemAlreadyExistsInProjectSection(tomlMap.get(PROJECT_SECTION_WITH_BRACKETS), trimmedLine)) {
+                                tomlMap.get(PROJECT_SECTION_WITH_BRACKETS).add(trimmedLine);
+                                List<String> additionaLines = checkPropertyForMultilineAdditions(
+                                        reader,
+                                        multiLineProperties,
+                                        currentKeyName,
+                                        lineCount
+                                );
+                                tomlMap.get(PROJECT_SECTION_WITH_BRACKETS).addAll(additionaLines);
+                                lineCount += additionaLines.size();
+                            }
+                        } else {
+                            // Non-migrate items
+                            tomlMap.get(currentSection).add(trimmedLine);
+                            List<String> additionaLines = checkPropertyForMultilineAdditions(
+                                    reader,
+                                    multiLineProperties,
+                                    currentKeyName,
+                                    lineCount
+                            );
+                            tomlMap.get(currentSection).addAll(additionaLines);
+                            lineCount += additionaLines.size();
+                        }
+                    }
+                } else {
+                    // Comments and blank lines
+                    if(currentSection.isEmpty()) {
+                        // comments at the top of the file that don't reside under
+                        // a section header
+                        if(!tomlMap.containsKey(NO_SECTION_HEADER)) {
+                            tomlMap.put(NO_SECTION_HEADER, new ArrayList<>());
+                        }
+                        tomlMap.get(NO_SECTION_HEADER).add(line);
+                    } else {
+                        tomlMap.get(currentSection).add(line);
+                    }
+                }
+            }
+
+            line = reader.readLine();
+            lineCount++;
+        }
+    }
+
+    /**
+     * If a migratable item is encountered before the project section is created
+     * then it will be added to the Map
+     */
+    private void ensureProjectSectionExistsInTomlMap() {
+        if(!tomlMap.containsKey(PROJECT_SECTION_WITH_BRACKETS)) {
+            tomlMap.put(PROJECT_SECTION_WITH_BRACKETS, new ArrayList<>());
+        }
+    }
+
+    /**
+     * If the current section is not already [project] and the item is in the list of migratable
+     * items then we need to migrate.
+     * @param currentKeyName the item being processed
+     * @return If the item needs to be migrated
+     */
+    private boolean itemNeedsToBeMigrated(String currentKeyName, String currentSection) {
+        return currentSection.equals("[" + TomlUtils.TOOL_POETRY + "]") && entriesToMigrate.contains(currentKeyName);
+    }
+
+    /**
+     * Checks if the current item is multi-line (formatted).  If it is we need to
+     * process the next few lines until the whole item is processed.
+     * @param reader the file being processed
+     * @param multiLineProperties a list of items that are multi-line
+     * @param currentKeyName the current item being processed
+     * @param lineCount the current position within the Toml file
+     * @return the last line that was processed
+     * @throws IOException
+     */
+    private List<String> checkPropertyForMultilineAdditions(BufferedReader reader, Map<String, TomlLocationBlock> multiLineProperties, String currentKeyName, int lineCount) throws IOException {
+        List<String> appendChangeSet = new ArrayList<>();
+        if(multiLineProperties.containsKey(currentKeyName)) {
+            TomlLocationBlock multilineBlock = multiLineProperties.get(currentKeyName);
+            if(multilineBlock != null) {
+                while (lineCount < multilineBlock.getEndLine()) {
+                    appendChangeSet.add(reader.readLine());
+                    lineCount++;
+                }
+            }
+        }
+        return appendChangeSet;
+    }
+
+    /**
+     * Extracts the key from the line
+     * i.e. version = "2.9.0.dev"
+     * @param trimmedLine the current line being processed
+     * @return the extracted key
+     */
+    private static String getKeyFromLine(String trimmedLine) {
+        return trimmedLine.substring(0, trimmedLine.indexOf(TomlUtils.EQUALS)).strip();
+    }
+
+    /**
+     * Check if the item already exists before adding.
+     * @param existingProjectItems a list of items that already exists in the [project] section
+     * @param migratingItem the current item being processed
+     * @return if the item already exists
+     */
+    private boolean checkIfItemAlreadyExistsInProjectSection(List<String> existingProjectItems, String migratingItem) {
+        String movingItemKey = migratingItem.substring(0, migratingItem.indexOf(TomlUtils.EQUALS) + 1);
+
+        boolean itemAlreadyExists = false;
+        for(String existingItem: existingProjectItems) {
+            if(existingItem.contains(movingItemKey)){
+                itemAlreadyExists = true;
+            }
         }
 
-        return true;
+        return itemAlreadyExists;
+    }
+
+    /**
+     * Takes the mapped toml file and outputs it line by line to a StringBuilder
+     * @return the StringBuilder of the processed file
+     * @throws IOException
+     */
+    private StringBuilder generateNewTomlFileContentsFromUpdatedStructure() throws IOException {
+        StringBuilder fileContent = new StringBuilder();
+
+        // Process items that were not part of a section first
+        if(tomlMap.containsKey(NO_SECTION_HEADER)) {
+            List<String> commentsWithoutASection = tomlMap.get(NO_SECTION_HEADER);
+            for (String line : commentsWithoutASection) {
+                fileContent.append(line).append("\n");
+            }
+            fileContent.append("").append("\n");
+        }
+
+        // Process the [project] section next so it's the first section of the toml file
+        List<String> projectItems = tomlMap.get(PROJECT_SECTION_WITH_BRACKETS);
+        fileContent.append(PROJECT_SECTION_WITH_BRACKETS).append("\n");
+
+        for (String line : projectItems) {
+            fileContent.append(line).append("\n");
+        }
+        fileContent.append("").append("\n");
+
+        for (Map.Entry<String, List<String>> entry : tomlMap.entrySet()) {
+            if(!entry.getKey().contains(TomlUtils.PROJECT) && !entry.getKey().contains(NO_SECTION_HEADER)) {
+                fileContent.append(entry.getKey()).append("\n");
+
+                for (String line : entry.getValue()) {
+                    fileContent.append(line).append("\n");
+                }
+            }
+        }
+
+        return fileContent;
     }
 
 }

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/util/TomlLocationBlock.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/util/TomlLocationBlock.java
@@ -1,0 +1,27 @@
+package org.technologybrewery.habushu.util;
+
+public class TomlLocationBlock {
+    private String keyName;
+    private int startLine;
+    private int endLine;
+
+    public TomlLocationBlock(String keyName, int startLine, int endLine) {
+        this.keyName = keyName;
+        this.startLine = startLine;
+        this.endLine = endLine;
+    }
+
+    public String getKeyName() {
+        return keyName;
+    }
+
+    public int getStartLine() {
+        return startLine;
+    }
+
+    public int getEndLine() {
+        return endLine;
+    }
+
+}
+

--- a/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-fields-in-tool-poetry.toml
+++ b/habushu-maven-plugin/src/test/resources/migration/poetry-v2/with-fields-in-tool-poetry.toml
@@ -1,11 +1,24 @@
+# A comment without a header
+
 [tool.poetry]
 name = "with-fields-in-tool-poetry"
 description = "Test moving entries from tool.poetry to project when Poetry version is at least 2.0.0"
 version = "2.9.0.dev"
-authors = ["Test <blah@foobar.com>"]
-maintainers = ["Test <blah@foobar.com>"]
+authors = [
+    "Test <blah@foobar.com>"
+]
+maintainers = [
+    "Test <blah@foobar.com>"
+]
+packages = [
+    {include = "example_1", from = "src"}
+]
 license = "MIT License"
-packages = [{include = "example_1", from = "src"}]
+
+# Ensure that generated code is included in package archives
+include = [
+    "src/my_package/generated/**/*"
+]
 
 [tool.poetry.dependencies]
 python = "^3.11"
@@ -15,7 +28,6 @@ uvicorn = {version = "^0.18.0", extras = ["standard"]}
 
 [tool.poetry.group.dev.dependencies]
 kappa-maki = ">=1.0.0"
-
 
 [build-system]
 requires = ["poetry-core>=1.6.0"]

--- a/habushu-maven-plugin/src/test/resources/specifications/poetry-v2/poetry-to-project-migration.feature
+++ b/habushu-maven-plugin/src/test/resources/specifications/poetry-v2/poetry-to-project-migration.feature
@@ -10,7 +10,7 @@ Feature: Test automatic migrations of required fields from [tool.project] to [pr
 
     Examples:
       | expectedToolPoetryEntries | expectedProjectEntries |
-      | 3                         | 6                      |
+      | 6                         | 4                      |
 
   Scenario Outline: Poetry version is at least 2.0.0 and there are overlapping fields between [tool.poetry] and [project]. Then, the poetry-to-project migration only migrates fields from [tool.poetry] that do not already exist in [project]
     Given the Poetry version is at least "2.0.0"
@@ -21,7 +21,7 @@ Feature: Test automatic migrations of required fields from [tool.project] to [pr
 
     Examples:
       | expectedToolPoetryEntries | expectedProjectEntries |
-      | 3                         | 6                      |
+      | 5                         | 4                      |
 
   Scenario: Poetry version is less than 2.0.0 and the poetry-to-project migration does not execute
     Given the Poetry version is less than "2.0.0"


### PR DESCRIPTION
Fixes a bug where an empty line is mistaken for a new section.
Also fixes a bug where properties that are multi-line and need to be migrated gets hashed.

## Summary by Sourcery

Refactor PoetryToProjectMigration to accurately migrate entries by parsing the TOML into a section-to-lines map, tracking multi-line blocks, and regenerating the file from that structure

Bug Fixes:
- Stop treating empty lines as new section headers during migration
- Preserve and properly migrate multi-line array properties instead of hashing them

Enhancements:
- Replace line-by-line flag parsing with a tomlMap structure and introduce TomlLocationBlock to record multi-line property ranges

Tests:
- Update test fixture to use block-style arrays for multi-line fields
- Adjust feature spec expected counts to reflect additional migrated entries