### PR TITLE
[#448] :green_heart: revert back to using the latest poetry version f…

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -37,8 +37,6 @@ jobs:
 
             - name: Install Poetry
               uses: snok/install-poetry@v1
-              with:
-                version: 2.1.4
 
             - name: Install uv
               uses: astral-sh/setup-uv@v5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,8 +31,6 @@ jobs:
                   python-version: '3.12.9'
             - name: Install Poetry
               uses: snok/install-poetry@v1
-              with:
-                version: 2.1.4
             - name: Install uv
               uses: astral-sh/setup-uv@v5
               with:


### PR DESCRIPTION
…or GitHub Action builds

## Summary by Sourcery

Build:
- Update CI and release GitHub Actions to stop pinning Poetry to version 2.1.4 and rely on the installer’s default latest version.