### PR TITLE
[#453] :arrow_up: maven-core update and related enforcer rule updates…

### DIFF
--- a/examples/poetry/habushu-poetry-enforcer-rule/README.md
+++ b/examples/poetry/habushu-poetry-enforcer-rule/README.md
@@ -12,7 +12,6 @@ project for Poetry versions.
 <plugin>
     <groupId>org.apache.maven.plugins</groupId>
     <artifactId>maven-enforcer-plugin</artifactId>
-    <version>3.5.0</version>
     <executions>
         <execution>
             <id>enforce-poetry</id>

--- a/examples/uv/habushu-uv-enforcer-rule/README.md
+++ b/examples/uv/habushu-uv-enforcer-rule/README.md
@@ -10,7 +10,6 @@ have created Maven Enforcer Rule, [requireUvVersion](../../../docs/CONFIGURATION
 <plugin>
     <groupId>org.apache.maven.plugins</groupId>
     <artifactId>maven-enforcer-plugin</artifactId>
-    <version>3.5.0</version>
     <executions>
         <execution>
             <id>enforce-uv</id>

--- a/habushu-maven-plugin/pom.xml
+++ b/habushu-maven-plugin/pom.xml
@@ -16,7 +16,7 @@
     <packaging>maven-plugin</packaging>
 
     <properties>
-        <version.maven>3.8.6</version.maven>
+        <version.maven>3.9.12</version.maven>
     </properties>
 
     <dependencyManagement>
@@ -24,14 +24,14 @@
             <dependency>
                 <groupId>io.cucumber</groupId>
                 <artifactId>cucumber-bom</artifactId>
-                <version>7.18.1</version>
+                <version>7.33.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.10.2</version>
+                <version>5.14.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -47,22 +47,22 @@
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
-            <version>4.0.1</version>
+            <version>4.0.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-exec</artifactId>
-            <version>1.4.0</version>
+            <version>1.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.18.0</version>
+            <version>3.20.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
-            <version>4.4</version>
+            <version>4.5.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -72,12 +72,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.9</version>
+            <version>2.0.17</version>
         </dependency>
         <dependency>
             <groupId>com.electronwill.night-config</groupId>
             <artifactId>toml</artifactId>
-            <version>3.8.1</version>
+            <version>3.8.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>org.technologybrewery.baton</groupId>
             <artifactId>baton-maven-plugin</artifactId>
-            <version>1.1.1</version>
+            <version>1.1.3</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
@@ -107,12 +107,12 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.16.1</version>
+            <version>2.21.0</version>
         </dependency>
         <dependency>
             <groupId>io.github.itning</groupId>
             <artifactId>guava-retrying3</artifactId>
-            <version>3.0.3</version>
+            <version>3.0.7</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>org.apache.velocity</groupId>
             <artifactId>velocity-engine-core</artifactId>
-            <version>2.3</version>
+            <version>2.4.1</version>
         </dependency>
 
         <!-- Provided Dependencies: -->
@@ -154,7 +154,7 @@
         <dependency>
             <groupId>org.apache.maven.enforcer</groupId>
             <artifactId>enforcer-api</artifactId>
-            <version>3.5.0</version>
+            <version>${version.maven.enforcer.plugin}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -205,7 +205,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
-            <version>1.12.0</version>
+            <version>1.15.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -231,6 +231,18 @@
                     <execution>
                         <id>default-descriptor</id>
                         <phase>process-classes</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.sisu</groupId>
+                <artifactId>sisu-maven-plugin</artifactId>
+                <version>0.9.0.M4</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>main-index</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/enforcer/AbstractRequireToolVersionRule.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/enforcer/AbstractRequireToolVersionRule.java
@@ -3,6 +3,7 @@ package org.technologybrewery.habushu.enforcer;
 import com.vdurmont.semver4j.Semver;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.maven.enforcer.rule.api.AbstractEnforcerRule;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleError;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 
 /**
@@ -21,7 +22,7 @@ public abstract class AbstractRequireToolVersionRule extends AbstractEnforcerRul
     protected String toolVersion;
 
     /**
-     * Returns a {@Pair} where the left side is the installation status of the tool and the right side is the version
+     * Returns a {@link Pair} where the left side is the installation status of the tool and the right side is the version
      * of the tool, if installed.
      *
      * @return installation/version pair for the tool
@@ -52,13 +53,13 @@ public abstract class AbstractRequireToolVersionRule extends AbstractEnforcerRul
     public void execute() throws EnforcerRuleException {
         Pair<Boolean, String> results = getInstalledAndVersionPair();
         if (Boolean.FALSE.equals(results.getLeft())) {
-            throw new EnforcerRuleException(getInstallationErrorMessage());
+            throw new EnforcerRuleError(getInstallationErrorMessage());
 
         } else {
             String foundVersion = results.getRight();
             Semver toolVersionSemver = new Semver(foundVersion, Semver.SemverType.NPM);
             if (!toolVersionSemver.satisfies(version)) {
-                throw new EnforcerRuleException(getVersionErrorMessage(foundVersion));
+                throw new EnforcerRuleError(getVersionErrorMessage(foundVersion));
 
             } else {
                 toolVersion = foundVersion;

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/enforcer/RequirePoetryVersionRule.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/enforcer/RequirePoetryVersionRule.java
@@ -3,6 +3,7 @@ package org.technologybrewery.habushu.enforcer;
 import org.apache.commons.lang3.tuple.Pair;
 import org.technologybrewery.habushu.exec.PoetryCommandHelper;
 
+import javax.inject.Inject;
 import javax.inject.Named;
 import java.io.File;
 
@@ -11,6 +12,11 @@ import java.io.File;
  */
 @Named("requirePoetryVersion")
 public class RequirePoetryVersionRule extends AbstractRequireToolVersionRule {
+
+    @Inject
+    public RequirePoetryVersionRule() {
+        super();
+    }
 
     /**
      * {@inheritDoc}

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/enforcer/RequirePyenvVersionRule.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/enforcer/RequirePyenvVersionRule.java
@@ -3,6 +3,7 @@ package org.technologybrewery.habushu.enforcer;
 import org.apache.commons.lang3.tuple.Pair;
 import org.technologybrewery.habushu.exec.PyenvCommandHelper;
 
+import javax.inject.Inject;
 import javax.inject.Named;
 import java.io.File;
 
@@ -11,6 +12,11 @@ import java.io.File;
  */
 @Named("requirePyenvVersion")
 public class RequirePyenvVersionRule extends AbstractRequireToolVersionRule {
+
+    @Inject
+    public RequirePyenvVersionRule() {
+        super();
+    }
 
     /**
      * {@inheritDoc}

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/enforcer/RequireUvVersionRule.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/enforcer/RequireUvVersionRule.java
@@ -3,6 +3,7 @@ package org.technologybrewery.habushu.enforcer;
 import org.apache.commons.lang3.tuple.Pair;
 import org.technologybrewery.habushu.exec.UvCommandHelper;
 
+import javax.inject.Inject;
 import javax.inject.Named;
 import java.io.File;
 
@@ -11,6 +12,11 @@ import java.io.File;
  */
 @Named("requireUvVersion")
 public class RequireUvVersionRule extends AbstractRequireToolVersionRule {
+
+    @Inject
+    public RequireUvVersionRule() {
+        super();
+    }
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
…; plexus update kicked to subsequent ticket

## Summary by Sourcery

Update habushu Maven plugin to use Maven 3.9.12 and align enforcer rules with newer Maven enforcer APIs.

Enhancements:
- Adjust custom enforcer rules to use EnforcerRuleError instead of EnforcerRuleException and ensure RequirePoetryVersionRule is properly injectable with a no-arg @Inject constructor.
- Remove hard-coded maven-enforcer-plugin versions from example READMEs to rely on managed/plugin versions instead.

Build:
- Bump Maven core version property to 3.9.12 and refresh multiple dependency versions (Cucumber, JUnit, Apache Commons libraries, SLF4J, Velocity, Baton plugin, Guava retrying, commons-io, commons-text, etc.).
- Add sisu-maven-plugin configuration to generate the main index required by newer Maven/Sisu integration.

Documentation:
- Update example enforcer rule READMEs to no longer pin a specific maven-enforcer-plugin version.