### PR TITLE
[#453] :green_heart: change granularity for timestamp check; :arrow_u…

### DIFF
--- a/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/ContainerizeDepsSteps.java
+++ b/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/ContainerizeDepsSteps.java
@@ -111,7 +111,9 @@ public class ContainerizeDepsSteps {
             Files.createFile(wheelPath);
         }
         Path dev0Path = appDist.resolve(APP_WHEEL);
-        Instant later = Files.getLastModifiedTime(dev0Path).toInstant().plus(1, ChronoUnit.MILLIS);
+        // Use 2 seconds to ensure filesystem timestamp granularity doesn't cause flaky tests
+        // (some filesystems only have second-level precision)
+        Instant later = Files.getLastModifiedTime(dev0Path).toInstant().plus(2, ChronoUnit.SECONDS);
         Files.setLastModifiedTime(wheelPath, FileTime.from(later));
     }
 

--- a/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/TestSpecifications.java
+++ b/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/TestSpecifications.java
@@ -1,8 +1,11 @@
 package org.technologybrewery.habushu;
 
-import org.junit.platform.suite.api.*;
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.ExcludeTags;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.SelectPackages;
+import org.junit.platform.suite.api.Suite;
 
-import static io.cucumber.junit.platform.engine.Constants.FILTER_TAGS_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
 
 /**
@@ -12,7 +15,7 @@ import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
  */
 @Suite
 @IncludeEngines("cucumber")
-@SelectClasspathResource("specifications")
+@SelectPackages("specifications")
 @ExcludeTags("manual")
 @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "org.technologybrewery.habushu")
 public class TestSpecifications {


### PR DESCRIPTION
…p: update cucumber annotation from deprecated one

## Summary by Sourcery

Adjust test configuration and timing to improve reliability of dependency containerization tests.

Tests:
- Increase timestamp offset in wheel file modification tests to avoid flakiness due to filesystem timestamp granularity.
- Update JUnit/Cucumber test suite selection from classpath resource to package-based selection for specifications tests.