### PR TITLE
[#456] :bug: fix breaking Poetry 2.3 dev version naming change

### DIFF
--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/ContainerizeDepsMojo.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/ContainerizeDepsMojo.java
@@ -358,7 +358,12 @@ public class ContainerizeDepsMojo extends AbstractHabushuMojo {
     protected String constructWheelNamePattern(CommandHelper commandHelper) {
         String normalizedName = commandHelper.getProjectName().replace('-', '_');
         String version = commandHelper.getProjectVersion();
-        //there could be a build descriptor, or a missing implied 0 as in 1.0.0.dev0
+        // #456: Poetry 2.3+ normalizes '.dev' to '.dev0' in version output, but wheels built with
+        // Poetry 2.2/uv use '.dev<timestamp>' without the '0'. Strip trailing '.dev0' to '.dev'
+        // so the pattern matches both formats: '.dev0', '.dev<timestamp>', and '.dev0<timestamp>'.
+        if (version.endsWith(".dev0")) {
+            version = version.substring(0, version.length() - 1);
+        }
         return normalizedName + "-" + version + "*-*-none-any.whl";
     }
 

--- a/habushu-maven-plugin/src/test/resources/specifications/containerize-dependencies.feature
+++ b/habushu-maven-plugin/src/test/resources/specifications/containerize-dependencies.feature
@@ -29,6 +29,18 @@ Feature: Test containerizing Python applications with monorepo dependencies
       | Poetry         |
       | uv             |
 
+  Scenario Outline: Multiple wheels match when using Poetry 2.3 dev0 timestamp format
+    Given a single "<packageManager>"-based dependency with packaging type Habushu
+    And a dockerfile to update
+    And a second wheel for the dependency "extensions_python_dep_X-1.0.0.dev01757432284715-py3-none-any.whl" created later
+    When the containerize-dependencies goal is executed
+    Then the "extensions_python_dep_X-1.0.0.dev01757432284715-py3-none-any.whl" wheel is staged
+    And the dockerfile installs the "extensions_python_dep_X-1.0.0.dev01757432284715-py3-none-any.whl" wheel
+    Examples:
+      | packageManager |
+      | Poetry         |
+      | uv             |
+
   Scenario Outline: Dockerfile is updated when it has injection point tag
     Given a single "<packageManager>"-based dependency with packaging type Habushu
     And a dockerfile to update


### PR DESCRIPTION
## Summary by Sourcery

Handle Poetry 2.3 development version naming so containerized dependency wheel selection remains compatible across tooling versions.

Bug Fixes:
- Fix wheel name matching to support Poetry 2.3+ '.dev0' normalization alongside existing timestamp-based dev versions.

Tests:
- Add scenario coverage ensuring the correct wheel is selected when multiple dev wheels exist using the new Poetry 2.3 timestamp format.