### PR TITLE
[#462] :sparkles: handle hatch build exclusion automatically for uv/h…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ generated/
 
 # ruff
 .ruff_cache/
+/.claude/settings.local.json

--- a/examples/uv/habushu-uv-dependency-groups/pyproject.toml
+++ b/examples/uv/habushu-uv-dependency-groups/pyproject.toml
@@ -32,3 +32,6 @@ publish-url = "https://pypi.org/simple/"
 indent-style="space"
 line-ending="lf"
 quote-style="preserve"
+
+[tool.hatch.build.targets.sdist]
+exclude = ["target/"]

--- a/examples/uv/habushu-uv-install-from-dev-repo/pyproject.toml
+++ b/examples/uv/habushu-uv-install-from-dev-repo/pyproject.toml
@@ -32,3 +32,6 @@ publish-url = "https://pypi.org/simple/"
 name = "private-repo"
 url = "http://127.0.0.1:8080/simple/"
 publish-url = "http://127.0.0.1:8080/"
+
+[tool.hatch.build.targets.sdist]
+exclude = ["target/"]

--- a/examples/uv/habushu-uv-package-consumer/pyproject.toml
+++ b/examples/uv/habushu-uv-package-consumer/pyproject.toml
@@ -28,3 +28,6 @@ publish-url = "https://pypi.org/simple/"
 dev = [
     "ruff>=0.11.5",
 ]
+
+[tool.hatch.build.targets.sdist]
+exclude = ["target/"]

--- a/examples/uv/habushu-uv-package/pyproject.toml
+++ b/examples/uv/habushu-uv-package/pyproject.toml
@@ -33,3 +33,6 @@ build-backend = "hatchling.build"
 name = "pypi"
 url = "https://pypi.org/simple/"
 publish-url = "https://pypi.org/simple/"
+
+[tool.hatch.build.targets.sdist]
+exclude = ["target/"]

--- a/examples/uv/habushu-uv-publish-to-dev-repo/pyproject.toml
+++ b/examples/uv/habushu-uv-publish-to-dev-repo/pyproject.toml
@@ -29,3 +29,6 @@ publish-url = "https://pypi.org/simple/"
 name = "private-repo"
 url = "http://127.0.0.1:8080/simple/"
 publish-url = "http://127.0.0.1:8080/"
+
+[tool.hatch.build.targets.sdist]
+exclude = ["target/"]

--- a/examples/uv/habushu-uv-pytest/pyproject.toml
+++ b/examples/uv/habushu-uv-pytest/pyproject.toml
@@ -34,3 +34,6 @@ publish-url = "https://pypi.org/simple/"
 dev = [
     "ruff>=0.11.12",
 ]
+
+[tool.hatch.build.targets.sdist]
+exclude = ["target/"]

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/migration/AbstractHabushuMigration.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/migration/AbstractHabushuMigration.java
@@ -11,4 +11,8 @@ public abstract class AbstractHabushuMigration extends AbstractMigration {
     protected boolean isPoetryProject(File pyProjectTomlFile) {
         return PackageManager.POETRY.equals(HabushuUtil.checkPythonPackageManager(pyProjectTomlFile));
     }
+
+    protected boolean isUvProject(File pyProjectTomlFile) {
+        return PackageManager.UV.equals(HabushuUtil.checkPythonPackageManager(pyProjectTomlFile));
+    }
 }

--- a/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/migration/HatchSdistExcludeMigration.java
+++ b/habushu-maven-plugin/src/main/java/org/technologybrewery/habushu/migration/HatchSdistExcludeMigration.java
@@ -1,0 +1,147 @@
+package org.technologybrewery.habushu.migration;
+
+import com.electronwill.nightconfig.core.file.FileConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.technologybrewery.baton.BatonException;
+import org.technologybrewery.habushu.util.TomlUtils;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Migration that automatically adds {@code [tool.hatch.build.targets.sdist]} configuration
+ * with {@code exclude = ["target/"]} for UV-based Habushu projects. This prevents the
+ * Maven target directory from being included in source distributions.
+ */
+public class HatchSdistExcludeMigration extends AbstractHabushuMigration {
+
+    private static final Logger logger = LoggerFactory.getLogger(HatchSdistExcludeMigration.class);
+
+    private static final String TOOL_HATCH_BUILD_TARGETS_SDIST = "tool.hatch.build.targets.sdist";
+    private static final String TOOL_HATCH_BUILD_TARGETS_SDIST_HEADER = "[tool.hatch.build.targets.sdist]";
+    private static final String EXCLUDE_KEY = "exclude";
+    private static final String TARGET_DIR = "target/";
+
+    private List<String> existingExcludes = null;
+
+    @Override
+    protected boolean shouldExecuteOnFile(File file) {
+        if (!isUvProject(file)) {
+            return false;
+        }
+
+        try (FileConfig toml = FileConfig.of(file)) {
+            toml.load();
+
+            List<String> excludeList = toml.get(TOOL_HATCH_BUILD_TARGETS_SDIST + "." + EXCLUDE_KEY);
+            if (excludeList != null) {
+                existingExcludes = new ArrayList<>(excludeList);
+                if (excludeList.contains(TARGET_DIR)) {
+                    // target/ is already excluded, no migration needed
+                    return false;
+                }
+            } else {
+                existingExcludes = null;
+            }
+
+            return true;
+        } catch (Exception e) {
+            throw new BatonException("Error reading pyproject.toml for hatch sdist exclude migration", e);
+        }
+    }
+
+    @Override
+    protected boolean performMigration(File file) {
+        try {
+            StringBuilder fileContent = new StringBuilder();
+            boolean sectionFound = false;
+            boolean excludeAdded = false;
+
+            try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    String trimmedLine = line.trim();
+
+                    // Check if this is the sdist section header
+                    if (trimmedLine.equals(TOOL_HATCH_BUILD_TARGETS_SDIST_HEADER)) {
+                        sectionFound = true;
+                        fileContent.append(line).append("\n");
+
+                        if (existingExcludes != null) {
+                            // Read through the section, skipping the exclude array (single or multi-line)
+                            line = reader.readLine();
+                            while (line != null && !line.trim().startsWith("[")) {
+                                if (line.trim().startsWith("exclude")) {
+                                    // Skip this line and any continuation lines if it's a multi-line array
+                                    if (!line.contains("]")) {
+                                        // Multi-line array - skip until we find the closing bracket
+                                        while ((line = reader.readLine()) != null && !line.contains("]")) {
+                                            // Skip array continuation lines
+                                        }
+                                        // The line with ']' is also skipped
+                                    }
+                                } else {
+                                    // Keep non-exclude lines in the section
+                                    fileContent.append(line).append("\n");
+                                }
+                                line = reader.readLine();
+                            }
+                            // Add the updated exclude list
+                            fileContent.append(buildExcludeLine()).append("\n");
+                            excludeAdded = true;
+                            // Process the line that broke the loop (next section header or null)
+                            if (line != null) {
+                                fileContent.append(line).append("\n");
+                            }
+                        } else {
+                            // Section exists but no exclude key - add exclude after the header
+                            fileContent.append(buildExcludeLine()).append("\n");
+                            excludeAdded = true;
+                        }
+                        continue;
+                    }
+
+                    fileContent.append(line).append("\n");
+                }
+            }
+
+            // If section wasn't found, append it at the end
+            if (!sectionFound && !excludeAdded) {
+                fileContent.append("\n").append(TOOL_HATCH_BUILD_TARGETS_SDIST_HEADER).append("\n");
+                fileContent.append(buildExcludeLine()).append("\n");
+            }
+
+            TomlUtils.writeTomlFile(file, fileContent.toString());
+            logger.info("Added target/ to [tool.hatch.build.targets.sdist] exclude list in {}", file.getName());
+            return true;
+        } catch (IOException e) {
+            throw new BatonException("Error performing hatch sdist exclude migration", e);
+        }
+    }
+
+    private String buildExcludeLine() {
+        List<String> excludes = new ArrayList<>();
+        if (existingExcludes != null) {
+            excludes.addAll(existingExcludes);
+        }
+        if (!excludes.contains(TARGET_DIR)) {
+            excludes.add(TARGET_DIR);
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(EXCLUDE_KEY).append(" = [");
+        for (int i = 0; i < excludes.size(); i++) {
+            if (i > 0) {
+                sb.append(", ");
+            }
+            sb.append("\"").append(excludes.get(i)).append("\"");
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+}

--- a/habushu-maven-plugin/src/main/resources/migrations.json
+++ b/habushu-maven-plugin/src/main/resources/migrations.json
@@ -124,6 +124,17 @@
             ]
           }
         ]
+      },
+      {
+        "name": "hatch-sdist-exclude-migration",
+        "implementation": "org.technologybrewery.habushu.migration.HatchSdistExcludeMigration",
+        "fileSets": [
+          {
+            "includes": [
+              "pyproject.toml"
+            ]
+          }
+        ]
       }
     ]
   }

--- a/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/migration/HatchSdistExcludeMigrationSteps.java
+++ b/habushu-maven-plugin/src/test/java/org/technologybrewery/habushu/migration/HatchSdistExcludeMigrationSteps.java
@@ -1,0 +1,95 @@
+package org.technologybrewery.habushu.migration;
+
+import com.electronwill.nightconfig.core.file.FileConfig;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+
+import java.io.File;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class HatchSdistExcludeMigrationSteps {
+
+    private static final String TEST_DIR = "./target/test-classes/migration/hatch-sdist";
+    private static final String TOOL_HATCH_BUILD_TARGETS_SDIST_EXCLUDE = "tool.hatch.build.targets.sdist.exclude";
+
+    private File pyProjectToml;
+    private boolean shouldExecute;
+    private boolean executionSucceeded;
+
+    @Given("a UV project without any hatch sdist configuration")
+    public void a_uv_project_without_any_hatch_sdist_configuration() {
+        pyProjectToml = new File(TEST_DIR, "uv-without-hatch-sdist.toml");
+    }
+
+    @Given("a UV project with hatch sdist exclude but without target directory")
+    public void a_uv_project_with_hatch_sdist_exclude_but_without_target_directory() {
+        pyProjectToml = new File(TEST_DIR, "uv-with-partial-hatch-sdist.toml");
+    }
+
+    @Given("a UV project with multi-line hatch sdist exclude without target directory")
+    public void a_uv_project_with_multi_line_hatch_sdist_exclude_without_target_directory() {
+        pyProjectToml = new File(TEST_DIR, "uv-with-multiline-hatch-sdist.toml");
+    }
+
+    @Given("a UV project with hatch sdist exclude already containing target directory")
+    public void a_uv_project_with_hatch_sdist_exclude_already_containing_target_directory() {
+        pyProjectToml = new File(TEST_DIR, "uv-with-complete-hatch-sdist.toml");
+    }
+
+    @Given("a Poetry project")
+    public void a_poetry_project() {
+        pyProjectToml = new File(TEST_DIR, "poetry-project.toml");
+    }
+
+    @When("the hatch sdist exclude migration executes")
+    public void the_hatch_sdist_exclude_migration_executes() {
+        HatchSdistExcludeMigration migration = new HatchSdistExcludeMigration();
+        shouldExecute = migration.shouldExecuteOnFile(pyProjectToml);
+        executionSucceeded = shouldExecute && migration.performMigration(pyProjectToml);
+    }
+
+    @Then("the pyproject.toml should have target directory in hatch sdist exclude list")
+    public void the_pyproject_toml_should_have_target_directory_in_hatch_sdist_exclude_list() {
+        assertTrue(shouldExecute, "Migration should have been selected to execute");
+        assertTrue(executionSucceeded, "Migration should have executed successfully");
+
+        try (FileConfig toml = FileConfig.of(pyProjectToml)) {
+            toml.load();
+            List<String> excludeList = toml.get(TOOL_HATCH_BUILD_TARGETS_SDIST_EXCLUDE);
+            assertNotNull(excludeList, "Exclude list should exist");
+            assertTrue(excludeList.contains("target/"), "Exclude list should contain target/");
+        }
+    }
+
+    @Then("the existing exclude entries should be preserved")
+    public void the_existing_exclude_entries_should_be_preserved() {
+        try (FileConfig toml = FileConfig.of(pyProjectToml)) {
+            toml.load();
+            List<String> excludeList = toml.get(TOOL_HATCH_BUILD_TARGETS_SDIST_EXCLUDE);
+            assertNotNull(excludeList, "Exclude list should exist");
+            assertTrue(excludeList.contains(".git/"), "Exclude list should still contain .git/");
+            assertTrue(excludeList.contains("docs/"), "Exclude list should still contain docs/");
+        }
+    }
+
+    @Then("the migration should not execute")
+    public void the_migration_should_not_execute() {
+        assertFalse(shouldExecute, "Migration should NOT have been selected to execute");
+    }
+
+    @Then("the exclude list should have {int} entries")
+    public void the_exclude_list_should_have_entries(Integer expectedCount) {
+        try (FileConfig toml = FileConfig.of(pyProjectToml)) {
+            toml.load();
+            List<String> excludeList = toml.get(TOOL_HATCH_BUILD_TARGETS_SDIST_EXCLUDE);
+            assertNotNull(excludeList, "Exclude list should exist");
+            assertEquals(expectedCount, excludeList.size(), "Exclude list should have " + expectedCount + " entries");
+        }
+    }
+}

--- a/habushu-maven-plugin/src/test/resources/migration/hatch-sdist/poetry-project.toml
+++ b/habushu-maven-plugin/src/test/resources/migration/hatch-sdist/poetry-project.toml
@@ -1,0 +1,12 @@
+[tool.poetry]
+name = "test-poetry-project"
+version = "1.0.0"
+description = "Test Poetry project that should be skipped"
+authors = ["Test <test@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+
+[build-system]
+requires = ["poetry-core>=1.6.0"]
+build-backend = "poetry.core.masonry.api"

--- a/habushu-maven-plugin/src/test/resources/migration/hatch-sdist/uv-with-complete-hatch-sdist.toml
+++ b/habushu-maven-plugin/src/test/resources/migration/hatch-sdist/uv-with-complete-hatch-sdist.toml
@@ -1,0 +1,13 @@
+[project]
+name = "test-uv-project"
+version = "1.0.0"
+description = "Test UV project with complete hatch sdist config"
+requires-python = ">=3.12"
+dependencies = []
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.sdist]
+exclude = [".git/", "target/", "docs/"]

--- a/habushu-maven-plugin/src/test/resources/migration/hatch-sdist/uv-with-multiline-hatch-sdist.toml
+++ b/habushu-maven-plugin/src/test/resources/migration/hatch-sdist/uv-with-multiline-hatch-sdist.toml
@@ -1,0 +1,16 @@
+[project]
+name = "test-uv-project"
+version = "1.0.0"
+description = "Test UV project with multi-line hatch sdist config"
+requires-python = ">=3.12"
+dependencies = []
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+    ".git/",
+    "docs/",
+]

--- a/habushu-maven-plugin/src/test/resources/migration/hatch-sdist/uv-with-partial-hatch-sdist.toml
+++ b/habushu-maven-plugin/src/test/resources/migration/hatch-sdist/uv-with-partial-hatch-sdist.toml
@@ -1,0 +1,13 @@
+[project]
+name = "test-uv-project"
+version = "1.0.0"
+description = "Test UV project with partial hatch sdist config"
+requires-python = ">=3.12"
+dependencies = []
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.sdist]
+exclude = [".git/", "docs/"]

--- a/habushu-maven-plugin/src/test/resources/migration/hatch-sdist/uv-without-hatch-sdist.toml
+++ b/habushu-maven-plugin/src/test/resources/migration/hatch-sdist/uv-without-hatch-sdist.toml
@@ -1,0 +1,10 @@
+[project]
+name = "test-uv-project"
+version = "1.0.0"
+description = "Test UV project without hatch sdist config"
+requires-python = ">=3.12"
+dependencies = []
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/habushu-maven-plugin/src/test/resources/specifications/hatch-sdist-exclude-migration.feature
+++ b/habushu-maven-plugin/src/test/resources/specifications/hatch-sdist-exclude-migration.feature
@@ -1,0 +1,32 @@
+@hatch-sdist
+Feature: Auto-add Hatch sdist exclude configuration for UV projects
+
+  Scenario: Add hatch sdist exclude to UV project without existing hatch config
+    Given a UV project without any hatch sdist configuration
+    When the hatch sdist exclude migration executes
+    Then the pyproject.toml should have target directory in hatch sdist exclude list
+    And the exclude list should have 1 entries
+
+  Scenario: Merge target directory into existing hatch sdist exclude list
+    Given a UV project with hatch sdist exclude but without target directory
+    When the hatch sdist exclude migration executes
+    Then the pyproject.toml should have target directory in hatch sdist exclude list
+    And the existing exclude entries should be preserved
+    And the exclude list should have 3 entries
+
+  Scenario: Merge target directory into existing multi-line hatch sdist exclude list
+    Given a UV project with multi-line hatch sdist exclude without target directory
+    When the hatch sdist exclude migration executes
+    Then the pyproject.toml should have target directory in hatch sdist exclude list
+    And the existing exclude entries should be preserved
+    And the exclude list should have 3 entries
+
+  Scenario: Skip migration when target directory already excluded
+    Given a UV project with hatch sdist exclude already containing target directory
+    When the hatch sdist exclude migration executes
+    Then the migration should not execute
+
+  Scenario: Skip migration for Poetry projects
+    Given a Poetry project
+    When the hatch sdist exclude migration executes
+    Then the migration should not execute


### PR DESCRIPTION
…atch pyproject.toml files

## Summary by Sourcery

Add an automatic migration to ensure UV-based Habushu projects exclude the Maven target directory from Hatch sdist builds and cover it with tests and examples.

New Features:
- Introduce a migration that adds or updates [tool.hatch.build.targets.sdist] configuration to exclude the Maven target directory for UV projects.

Enhancements:
- Extend migration base class with UV project detection helper.
- Update UV example pyproject.toml files to include Hatch sdist configuration that excludes the target directory.

Tests:
- Add Cucumber feature scenarios and step definitions to validate the Hatch sdist exclude migration behavior across different UV and Poetry project configurations.